### PR TITLE
Add a new MergeMultiOperator interface which supports PartialMergeMulti

### DIFF
--- a/merge_multi_operator.go
+++ b/merge_multi_operator.go
@@ -1,0 +1,27 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+import "C"
+
+// MergeMultiOperator is similar to a MergeOperator but implements PartialMergeMulti
+// When given a MergeMultiOperator, the PartialMergeMulti will always
+// be used instead of PartialMerge
+type MergeMultiOperator interface {
+	MergeOperator
+	// PartialMerge performs merge on multiple operands
+	// when all of the operands are themselves merge operation types
+	// that you would have passed to a db.Merge() call in the same order
+	// (i.e.: db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
+	// ... db.Merge(key, operand[n])).
+	//
+	// PartialMerge should combine them into a single merge operation.
+	// The return value should be constructed such that a call to
+	// db.Merge(key, new_value) would yield the same result as a call
+	// to db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
+	// ... db.Merge(key, operand[n])).
+	//
+	// If it is impossible or infeasible to combine the operations, return false.
+	// The library will internally keep track of the operations, and apply them in the
+	// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
+	PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool)
+}

--- a/merge_multi_operator.go
+++ b/merge_multi_operator.go
@@ -3,11 +3,10 @@ package gorocksdb
 // #include "rocksdb/c.h"
 import "C"
 
-// MergeMultiOperator is similar to a MergeOperator but implements PartialMergeMulti
-// When given a MergeMultiOperator, the PartialMergeMulti will always
-// be used instead of PartialMerge
+// MergeMultiOperator implements PartialMergeMulti(key []byte, operands [][]byte) ([]byte, err)
+// When a MergeOperator implements this interface, PartialMergeMulti
+// will be used instead of PartialMerge
 type MergeMultiOperator interface {
-	MergeOperator
 	// PartialMerge performs merge on multiple operands
 	// when all of the operands are themselves merge operation types
 	// that you would have passed to a db.Merge() call in the same order

--- a/merge_multi_operator_test.go
+++ b/merge_multi_operator_test.go
@@ -1,0 +1,82 @@
+package gorocksdb
+
+import (
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestMergeMultiOperator(t *testing.T) {
+	var (
+		givenKey     = []byte("hello")
+		startingVal  = []byte("foo")
+		mergeVal1    = []byte("bar")
+		mergeVal2    = []byte("baz")
+		fMergeResult = []byte("foobarbaz")
+		pMergeResult = []byte("barbaz")
+	)
+
+	merger := &mockMergeMultiOperator{
+		fullMerge: func(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, existingValue, startingVal)
+			ensure.DeepEqual(&fatalAsError{t}, operands[0], pMergeResult)
+			return fMergeResult, true
+		},
+		partialMerge: func(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+			t.FailNow() // this should never be called
+			return nil, false
+		},
+		partialMergeMulti: func(key []byte, operands [][]byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, operands[0], mergeVal1)
+			ensure.DeepEqual(&fatalAsError{t}, operands[1], mergeVal2)
+			return pMergeResult, true
+		},
+	}
+	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+		opts.SetMergeOperator(merger)
+	})
+	defer db.Close()
+
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+
+	// insert a starting value and compact to trigger merges
+	ensure.Nil(t, db.Put(wo, givenKey, startingVal))
+
+	// trigger a compaction to ensure that a merge is performed
+	db.CompactRange(Range{nil, nil})
+
+	// we expect these two operands to be passed to merge multi
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal1))
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal2))
+
+	// trigger a compaction to ensure that a
+	// partial and full merge are performed
+	db.CompactRange(Range{nil, nil})
+
+	ro := NewDefaultReadOptions()
+	v1, err := db.Get(ro, givenKey)
+	defer v1.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v1.Data(), fMergeResult)
+
+}
+
+type mockMergeMultiOperator struct {
+	fullMerge         func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+	partialMerge      func(key, leftOperand, rightOperand []byte) ([]byte, bool)
+	partialMergeMulti func(key []byte, operands [][]byte) ([]byte, bool)
+}
+
+func (m *mockMergeMultiOperator) Name() string { return "gorocksdb.test" }
+func (m *mockMergeMultiOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+	return m.fullMerge(key, existingValue, operands)
+}
+func (m *mockMergeMultiOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+	return m.partialMerge(key, leftOperand, rightOperand)
+}
+func (m *mockMergeMultiOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
+	return m.partialMergeMulti(key, operands)
+}

--- a/merge_operator.go
+++ b/merge_operator.go
@@ -28,22 +28,20 @@ type MergeOperator interface {
 	// internal corruption. This will be treated as an error by the library.
 	FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool)
 
-	// PartialMergeMulti performs merge on multiple operands
-	// when all of the operands are themselves merge operation types
+	// This function performs merge(left_op, right_op)
+	// when both the operands are themselves merge operation types
 	// that you would have passed to a db.Merge() call in the same order
-	// (i.e.: db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
-	// ... db.Merge(key, operand[n])).
+	// (i.e.: db.Merge(key,left_op), followed by db.Merge(key,right_op)).
 	//
-	// PartialMergeMulti should combine them into a single merge operation.
+	// PartialMerge should combine them into a single merge operation.
 	// The return value should be constructed such that a call to
 	// db.Merge(key, new_value) would yield the same result as a call
-	// to db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
-	// ... db.Merge(key, operand[n])).
+	// to db.Merge(key, left_op) followed by db.Merge(key, right_op).
 	//
-	// If it is impossible or infeasible to combine the operations, return false.
+	// If it is impossible or infeasible to combine the two operations, return false.
 	// The library will internally keep track of the operations, and apply them in the
 	// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
-	PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool)
+	PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool)
 
 	// The name of the MergeOperator.
 	Name() string
@@ -61,7 +59,7 @@ type nativeMergeOperator struct {
 func (mo nativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return nil, false
 }
-func (mo nativeMergeOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
+func (mo nativeMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
 	return nil, false
 }
 func (mo nativeMergeOperator) Name() string { return "" }
@@ -111,7 +109,21 @@ func gorocksdb_mergeoperator_partial_merge_multi(idx int, cKey *C.char, cKeyLen 
 	var newValue []byte
 	success := true
 
-	newValue, success = mergeOperators.Get(idx).(mergeOperatorWrapper).mergeOperator.PartialMergeMulti(key, operands)
+	merger := mergeOperators.Get(idx).(mergeOperatorWrapper).mergeOperator
+
+	// if there is a MergeMultiOperator, use it, otherwise use the MergeOperator
+	if mmo, ok := merger.(MergeMultiOperator); ok {
+		newValue, success = mmo.PartialMergeMulti(key, operands)
+	} else {
+		leftOperand := operands[0]
+		for i := 1; i < int(cNumOperands); i++ {
+			newValue, success = merger.PartialMerge(key, leftOperand, operands[i])
+			if !success {
+				break
+			}
+			leftOperand = newValue
+		}
+	}
 
 	newValueLen := len(newValue)
 	*cNewValueLen = C.size_t(newValueLen)

--- a/merge_operator.go
+++ b/merge_operator.go
@@ -28,24 +28,22 @@ type MergeOperator interface {
 	// internal corruption. This will be treated as an error by the library.
 	FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool)
 
-	// This function performs merge on multiple operands
+	// PartialMergeMulti performs merge on multiple operands
 	// when all of the operands are themselves merge operation types
 	// that you would have passed to a db.Merge() call in the same order
 	// (i.e.: db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
 	// ... db.Merge(key, operand[n])).
 	//
-	// PartialMerge should combine them into a single merge operation.
+	// PartialMergeMulti should combine them into a single merge operation.
 	// The return value should be constructed such that a call to
 	// db.Merge(key, new_value) would yield the same result as a call
 	// to db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
 	// ... db.Merge(key, operand[n])).
 	//
 	// If it is impossible or infeasible to combine the operations, return false.
-	// The library will attempt to call PartialMerge with each operand if
-	// PartialMergeMulti returns false.
 	// The library will internally keep track of the operations, and apply them in the
 	// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
-	PartialMerge(key []byte, operands [][]byte) ([]byte, bool)
+	PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool)
 
 	// The name of the MergeOperator.
 	Name() string
@@ -63,7 +61,7 @@ type nativeMergeOperator struct {
 func (mo nativeMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return nil, false
 }
-func (mo nativeMergeOperator) PartialMerge(key []byte, operands [][]byte) ([]byte, bool) {
+func (mo nativeMergeOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
 	return nil, false
 }
 func (mo nativeMergeOperator) Name() string { return "" }
@@ -113,7 +111,7 @@ func gorocksdb_mergeoperator_partial_merge_multi(idx int, cKey *C.char, cKeyLen 
 	var newValue []byte
 	success := true
 
-	newValue, success = mergeOperators.Get(idx).(mergeOperatorWrapper).mergeOperator.PartialMerge(key, operands)
+	newValue, success = mergeOperators.Get(idx).(mergeOperatorWrapper).mergeOperator.PartialMergeMulti(key, operands)
 
 	newValueLen := len(newValue)
 	*cNewValueLen = C.size_t(newValueLen)

--- a/merge_operator.go
+++ b/merge_operator.go
@@ -28,6 +28,14 @@ type MergeOperator interface {
 	// internal corruption. This will be treated as an error by the library.
 	FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool)
 
+	// The name of the MergeOperator.
+	Name() string
+}
+
+// PartialMerger implements PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, err)
+// When a MergeOperator implements this interface, PartialMerge will be called in addition
+// to FullMerge for compactions across levels
+type PartialMerger interface {
 	// This function performs merge(left_op, right_op)
 	// when both the operands are themselves merge operation types
 	// that you would have passed to a db.Merge() call in the same order
@@ -42,9 +50,28 @@ type MergeOperator interface {
 	// The library will internally keep track of the operations, and apply them in the
 	// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
 	PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool)
+}
 
-	// The name of the MergeOperator.
-	Name() string
+// MultiMerger implements PartialMergeMulti(key []byte, operands [][]byte) ([]byte, err)
+// When a MergeOperator implements this interface, PartialMergeMulti will be called in addition
+// to FullMerge for compactions across levels
+type MultiMerger interface {
+	// PartialMerge performs merge on multiple operands
+	// when all of the operands are themselves merge operation types
+	// that you would have passed to a db.Merge() call in the same order
+	// (i.e.: db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
+	// ... db.Merge(key, operand[n])).
+	//
+	// PartialMerge should combine them into a single merge operation.
+	// The return value should be constructed such that a call to
+	// db.Merge(key, new_value) would yield the same result as a call
+	// to db.Merge(key,operand[0]), followed by db.Merge(key,operand[1]),
+	// ... db.Merge(key, operand[n])).
+	//
+	// If it is impossible or infeasible to combine the operations, return false.
+	// The library will internally keep track of the operations, and apply them in the
+	// correct order once a base-value (a Put/Delete/End-of-Database) is seen.
+	PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool)
 }
 
 // NewNativeMergeOperator creates a MergeOperator object.
@@ -111,18 +138,21 @@ func gorocksdb_mergeoperator_partial_merge_multi(idx int, cKey *C.char, cKeyLen 
 
 	merger := mergeOperators.Get(idx).(mergeOperatorWrapper).mergeOperator
 
-	// if there is a MergeMultiOperator, use it, otherwise use the MergeOperator
-	if mmo, ok := merger.(MergeMultiOperator); ok {
-		newValue, success = mmo.PartialMergeMulti(key, operands)
-	} else {
+	// check if this MergeOperator supports partial or multi merges
+	switch v := merger.(type) {
+	case MultiMerger:
+		newValue, success = v.PartialMergeMulti(key, operands)
+	case PartialMerger:
 		leftOperand := operands[0]
 		for i := 1; i < int(cNumOperands); i++ {
-			newValue, success = merger.PartialMerge(key, leftOperand, operands[i])
+			newValue, success = v.PartialMerge(key, leftOperand, operands[i])
 			if !success {
 				break
 			}
 			leftOperand = newValue
 		}
+	default:
+		success = false
 	}
 
 	newValueLen := len(newValue)

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -40,15 +40,146 @@ func TestMergeOperator(t *testing.T) {
 	ensure.DeepEqual(t, v1.Data(), givenMerged)
 }
 
+func TestPartialMergeOperator(t *testing.T) {
+	var (
+		givenKey     = []byte("hello")
+		startingVal  = []byte("foo")
+		mergeVal1    = []byte("bar")
+		mergeVal2    = []byte("baz")
+		fMergeResult = []byte("foobarbaz")
+		pMergeResult = []byte("barbaz")
+	)
+
+	merger := &mockMergePartialOperator{
+		fullMerge: func(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, existingValue, startingVal)
+			ensure.DeepEqual(&fatalAsError{t}, operands[0], pMergeResult)
+			return fMergeResult, true
+		},
+		partialMerge: func(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, leftOperand, mergeVal1)
+			ensure.DeepEqual(&fatalAsError{t}, rightOperand, mergeVal2)
+			return pMergeResult, true
+		},
+	}
+	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+		opts.SetMergeOperator(merger)
+	})
+	defer db.Close()
+
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+
+	// insert a starting value and compact to trigger merges
+	ensure.Nil(t, db.Put(wo, givenKey, startingVal))
+
+	// trigger a compaction to ensure that a merge is performed
+	db.CompactRange(Range{nil, nil})
+
+	// we expect these two operands to be passed to merge partial
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal1))
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal2))
+
+	// trigger a compaction to ensure that a
+	// partial and full merge are performed
+	db.CompactRange(Range{nil, nil})
+
+	ro := NewDefaultReadOptions()
+	v1, err := db.Get(ro, givenKey)
+	defer v1.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v1.Data(), fMergeResult)
+
+}
+
+func TestMergeMultiOperator(t *testing.T) {
+	var (
+		givenKey     = []byte("hello")
+		startingVal  = []byte("foo")
+		mergeVal1    = []byte("bar")
+		mergeVal2    = []byte("baz")
+		fMergeResult = []byte("foobarbaz")
+		pMergeResult = []byte("barbaz")
+	)
+
+	merger := &mockMergeMultiOperator{
+		fullMerge: func(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, existingValue, startingVal)
+			ensure.DeepEqual(&fatalAsError{t}, operands[0], pMergeResult)
+			return fMergeResult, true
+		},
+		partialMergeMulti: func(key []byte, operands [][]byte) ([]byte, bool) {
+			ensure.DeepEqual(&fatalAsError{t}, key, givenKey)
+			ensure.DeepEqual(&fatalAsError{t}, operands[0], mergeVal1)
+			ensure.DeepEqual(&fatalAsError{t}, operands[1], mergeVal2)
+			return pMergeResult, true
+		},
+	}
+	db := newTestDB(t, "TestMergeOperator", func(opts *Options) {
+		opts.SetMergeOperator(merger)
+	})
+	defer db.Close()
+
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+
+	// insert a starting value and compact to trigger merges
+	ensure.Nil(t, db.Put(wo, givenKey, startingVal))
+
+	// trigger a compaction to ensure that a merge is performed
+	db.CompactRange(Range{nil, nil})
+
+	// we expect these two operands to be passed to merge multi
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal1))
+	ensure.Nil(t, db.Merge(wo, givenKey, mergeVal2))
+
+	// trigger a compaction to ensure that a
+	// partial and full merge are performed
+	db.CompactRange(Range{nil, nil})
+
+	ro := NewDefaultReadOptions()
+	v1, err := db.Get(ro, givenKey)
+	defer v1.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v1.Data(), fMergeResult)
+
+}
+
+// Mock Objects
 type mockMergeOperator struct {
-	fullMerge    func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
-	partialMerge func(key, leftOperand, rightOperand []byte) ([]byte, bool)
+	fullMerge func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
 }
 
 func (m *mockMergeOperator) Name() string { return "gorocksdb.test" }
 func (m *mockMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return m.fullMerge(key, existingValue, operands)
 }
-func (m *mockMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+
+type mockMergeMultiOperator struct {
+	fullMerge         func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+	partialMergeMulti func(key []byte, operands [][]byte) ([]byte, bool)
+}
+
+func (m *mockMergeMultiOperator) Name() string { return "gorocksdb.multi" }
+func (m *mockMergeMultiOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+	return m.fullMerge(key, existingValue, operands)
+}
+func (m *mockMergeMultiOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
+	return m.partialMergeMulti(key, operands)
+}
+
+type mockMergePartialOperator struct {
+	fullMerge    func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+	partialMerge func(key, leftOperand, rightOperand []byte) ([]byte, bool)
+}
+
+func (m *mockMergePartialOperator) Name() string { return "gorocksdb.partial" }
+func (m *mockMergePartialOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+	return m.fullMerge(key, existingValue, operands)
+}
+func (m *mockMergePartialOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
 	return m.partialMerge(key, leftOperand, rightOperand)
 }

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -41,14 +41,14 @@ func TestMergeOperator(t *testing.T) {
 }
 
 type mockMergeOperator struct {
-	fullMerge         func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
-	partialMergeMulti func(key []byte, operands [][]byte) ([]byte, bool)
+	fullMerge    func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+	partialMerge func(key, leftOperand, rightOperand []byte) ([]byte, bool)
 }
 
 func (m *mockMergeOperator) Name() string { return "gorocksdb.test" }
 func (m *mockMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return m.fullMerge(key, existingValue, operands)
 }
-func (m *mockMergeOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
-	return m.partialMergeMulti(key, operands)
+func (m *mockMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
+	return m.partialMerge(key, leftOperand, rightOperand)
 }

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -42,7 +42,6 @@ func TestMergeOperator(t *testing.T) {
 
 type mockMergeOperator struct {
 	fullMerge         func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
-	partialMerge      func(key, leftOperand, rightOperand []byte) ([]byte, bool)
 	partialMergeMulti func(key []byte, operands [][]byte) ([]byte, bool)
 }
 
@@ -50,9 +49,6 @@ func (m *mockMergeOperator) Name() string { return "gorocksdb.test" }
 func (m *mockMergeOperator) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
 	return m.fullMerge(key, existingValue, operands)
 }
-func (m *mockMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
-	return m.partialMerge(key, leftOperand, rightOperand)
-}
 func (m *mockMergeOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
-	return nil, false
+	return m.partialMergeMulti(key, operands)
 }

--- a/merge_operator_test.go
+++ b/merge_operator_test.go
@@ -41,8 +41,9 @@ func TestMergeOperator(t *testing.T) {
 }
 
 type mockMergeOperator struct {
-	fullMerge    func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
-	partialMerge func(key, leftOperand, rightOperand []byte) ([]byte, bool)
+	fullMerge         func(key, existingValue []byte, operands [][]byte) ([]byte, bool)
+	partialMerge      func(key, leftOperand, rightOperand []byte) ([]byte, bool)
+	partialMergeMulti func(key []byte, operands [][]byte) ([]byte, bool)
 }
 
 func (m *mockMergeOperator) Name() string { return "gorocksdb.test" }
@@ -51,4 +52,7 @@ func (m *mockMergeOperator) FullMerge(key, existingValue []byte, operands [][]by
 }
 func (m *mockMergeOperator) PartialMerge(key, leftOperand, rightOperand []byte) ([]byte, bool) {
 	return m.partialMerge(key, leftOperand, rightOperand)
+}
+func (m *mockMergeOperator) PartialMergeMulti(key []byte, operands [][]byte) ([]byte, bool) {
+	return nil, false
 }


### PR DESCRIPTION
**Problem**
The current PartialMerge function accepts a left and right operand and is called many times by this function: https://github.com/DataDog/gorocksdb/blob/master/merge_operator.go#L100 This means we have to deserialize / unmarshal those byte arrays into comparable objects for merging many, many times.

**Proposal:**
A new MergeMultiOperator which includes the `PartialMergeMulti(key []byte, operands [][]byte) ([]byte, error)` .  This allows us to implement the MergeMultiOperator interface.  In the `gorocksdb_mergeoperator_partial_merge_multi` fucntion, a type assertion is done on the MergeOperator, and if it is a MergeMultiOperator, the PartialMergeMulti function is used, otherwise the existing behavior stays intact.