### PR TITLE
[fix] static link dl

### DIFF
--- a/staticflag_linux.go
+++ b/staticflag_linux.go
@@ -2,5 +2,5 @@
 
 package gorocksdb
 
-// #cgo LDFLAGS: -l:librocksdb.a -l:libstdc++.a -l:libz.a -l:libbz2.a -l:libsnappy.a -l:liblz4.a -l:libzstd.a -lm
+// #cgo LDFLAGS: -l:librocksdb.a -l:libstdc++.a -l:libz.a -l:libbz2.a -l:libsnappy.a -l:liblz4.a -l:libzstd.a -lm -ldl
 import "C"


### PR DESCRIPTION
We added an `'ldl` flag to the dynflag.go but we also need it in staticflag_linux.go when building a static library.