### PR TITLE
Add missing FlushCF method

### DIFF
--- a/db_v6.go
+++ b/db_v6.go
@@ -1,0 +1,19 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+import "C"
+import(
+	"errors"
+	"unsafe"
+)
+
+// FlushCF triggers a manual flush for the column camily.
+func (db *DB) FlushCF(cf *ColumnFamilyHandle, opts *FlushOptions) error {
+	var cErr *C.char
+	C.rocksdb_flush_cf(db.c, opts.c, cf.c, &cErr)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return errors.New(C.GoString(cErr))
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds the "FlushCF" method for flushing a column family.

Note that this will not compile with rocksdb < v6. Although rocksdb supported flushing column families before rocksdb v6, `rocksdb_flush_cf ` was not added to the C API until v6 and this change has not been back-ported.

I put this function in a `db_v6.go` file moreso for organizational purposes than to actually help with any build process.