### PR TITLE
Adding support for setting total_order_seek

### DIFF
--- a/options_read.go
+++ b/options_read.go
@@ -129,6 +129,18 @@ func (opts *ReadOptions) SetReadaheadSize(value uint64) {
 	C.rocksdb_readoptions_set_readahead_size(opts.c, C.size_t(value))
 }
 
+// SetTotalOrderSeek specifies the value of "total_order_seek".
+// Enable a total order seek regardless of index format (e.g. hash index)
+// used in the table. Some table format (e.g. plain table) may not support
+// this option.
+// If true when calling Get(), we also skip prefix bloom when reading from
+// block based table. It provides a way to read existing data after
+// changing implementation of prefix extractor.
+// Default: false
+func (opts *ReadOptions) SetTotalOrderSeek(value bool) {
+	C.rocksdb_readoptions_set_total_order_seek(opts.c, boolToChar(value))
+}
+
 // Destroy deallocates the ReadOptions object.
 func (opts *ReadOptions) Destroy() {
 	C.rocksdb_readoptions_destroy(opts.c)


### PR DESCRIPTION
Adding support for setting total_order_seek so that its reasonable to query with less than the full prefix.