### PR TITLE
Add missing FlushCF method

### DIFF
--- a/db.go
+++ b/db.go
@@ -752,6 +752,17 @@ func (db *DB) Flush(opts *FlushOptions) error {
 	return nil
 }
 
+// FlushCF triggers a manual flush for the column family.
+func (db *DB) FlushCF(cf *ColumnFamilyHandle, opts *FlushOptions) error {
+	var cErr *C.char
+	C.rocksdb_flush_cf(db.c, opts.c, cf.c, &cErr)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return errors.New(C.GoString(cErr))
+	}
+	return nil
+} 
+
 // DisableFileDeletions disables file deletions and should be used when backup the database.
 func (db *DB) DisableFileDeletions() error {
 	var cErr *C.char

--- a/db_test.go
+++ b/db_test.go
@@ -243,3 +243,29 @@ func TestDBGetApproximateSizesCF(t *testing.T) {
 	sizes = db.GetApproximateSizesCF(cf, []Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
 	ensure.DeepEqual(t, sizes, []uint64{0})
 }
+
+func TestDBFlushCF(t *testing.T) {
+	var (
+		db = newTestDB(t, "TestDBFlushCF", nil)
+		o  = NewDefaultOptions()
+		wo = NewDefaultWriteOptions()
+		fo = NewDefaultFlushOptions()
+
+		key1 = []byte("hello1")
+		val1 = []byte("world1")
+	)
+	defer func() {
+		fo.Destroy()
+		wo.Destroy()
+		db.Close()
+	}()
+
+	cf, err := db.CreateColumnFamily(o, "other")
+	ensure.Nil(t, err)
+
+	// update
+	ensure.Nil(t, db.PutCF(wo, cf, key1, val1))
+
+	// flush CF
+	ensure.Nil(t, db.FlushCF(cf, fo))
+}


### PR DESCRIPTION
Adds the FlushCF method that was added to the C API in rocksdb 6.

Note that although rocksdb 5.* has FlushCF, it was not exposed in the C API and was not backported.