### PR TITLE
Add in GetTickerCount, GetAndResetTickerCount, SetStatsLevel, and Get…

### DIFF
--- a/dynflag.go
+++ b/dynflag.go
@@ -3,4 +3,5 @@
 package gorocksdb
 
 // #cgo LDFLAGS: -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd -ldl
+// #cgo CXXFLAGS: --std=c++11
 import "C"

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -28,3 +28,17 @@ extern void gorocksdb_mergeoperator_delete_value(void* state, const char* v, siz
 /* Slice Transform */
 
 extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(uintptr_t idx);
+
+/* Statistics/Tickers */
+#ifdef __cplusplus__
+extern "C" {
+#endif
+
+uint64_t gorocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker);
+uint64_t gorocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker);
+void gorocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level);
+uint8_t gorocksdb_get_stats_level(rocksdb_options_t *options);
+
+#ifdef __cplusplus__
+}
+#endif

--- a/gorocksdb.h
+++ b/gorocksdb.h
@@ -2,6 +2,9 @@
 #include "rocksdb/c.h"
 
 // This API provides convenient C wrapper functions for rocksdb client.
+#ifdef __cplusplus__
+extern "C" {
+#endif
 
 /* Base */
 
@@ -30,14 +33,16 @@ extern void gorocksdb_mergeoperator_delete_value(void* state, const char* v, siz
 extern rocksdb_slicetransform_t* gorocksdb_slicetransform_create(uintptr_t idx);
 
 /* Statistics/Tickers */
-#ifdef __cplusplus__
-extern "C" {
-#endif
 
-uint64_t gorocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker);
-uint64_t gorocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker);
-void gorocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level);
-uint8_t gorocksdb_get_stats_level(rocksdb_options_t *options);
+uint64_t rocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker);
+uint64_t rocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker);
+void rocksdb_record_tick(rocksdb_options_t *options, uint32_t ticker, uint64_t count);
+void rocksdb_set_ticker_count(rocksdb_options_t *options, uint32_t ticker, uint64_t count);
+
+void rocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level);
+uint8_t rocksdb_get_stats_level(rocksdb_options_t *options);
+
+void rocksdb_block_based_options_set_flush_every_key_policy(rocksdb_block_based_table_options_t *opts);
 
 #ifdef __cplusplus__
 }

--- a/options.go
+++ b/options.go
@@ -69,6 +69,170 @@ const (
 	SkipAnyCorruptedRecordsRecovery      = WALRecoveryMode(3)
 )
 
+type Ticker uint32
+
+// Options for use in GetTickerCount and GetAndResetTickerCount
+// For definitions of individual flags, see <rocksdb/statistics.h>
+const (
+	BlockCacheMiss             = Ticker(0)
+	BlockCacheHit
+	BlockCacheAdd
+	BlockCacheAddFailures
+	BlockCacheIndexMiss
+	BlockCacheIndexHit
+	BlockCacheIndexAdd
+	BlockCacheIndexBytesInsert
+	BlockCacheIndexBytesEvict
+	BlockCacheDataMiss
+	BlockCacheDataHit
+	BlockCacheDataAdd
+	BlockCacheDataBytesInsert
+	BlockCacheBytesRead
+	BlockCacheBytesWrite
+	BloomFilterUseful
+	BloomFilterFullPositive
+	BloomFilterFullTruePositive
+	BloomFilterMicros
+	PersistentCacheHit
+	PersistentCacheMiss
+	SimBlockCacheHit
+	SimBlockCacheMiss
+	MemtableHit
+	MemtableMiss
+	GetHitL0
+	GetHitL1
+	GetHitL2AndUp
+	CompactionKeyDropNewerEntry
+	CompcationKeyDropObsolete
+	CompactionKeyDropRangeDel
+	CompactionKeyDropUser
+	CompactionRangeDelDropObsolete
+	CompactionOptimizedDelDropObsolete
+	CompactionCancelled
+	NumberKeysWritten
+	NumberKeysRead
+	NumberKeysUpdated
+	BytesWritten
+	BytesRead
+	NumberDbSeek
+	NumberDbNext
+	NumberDbPrev
+	NumberDbSeekFound
+	NumberDbNextFound
+	NumberDbPrevFound
+	IterBytesRead
+	NoFileCloses
+	NoFileOpens
+	NoFileErrors
+	StallL0SlowdownMicros
+	StallMemtableCompactionMicros
+	StallL0NumFilesMicros
+	StallMicros
+	DbMutexWaitMicros
+	RateLimitDelayMillis
+	NoIterators           // Deprecated
+	NumberMultigetCalls
+	NumberMultigetKeysRead
+	NumberMultigetBytesRead
+	NumberFilteredDeletes
+	NumberMergeFailures
+	BloomFilterPrefixChecked
+	BloomFilterPrefixUseful
+	NumberOfReseeksInIteration
+	GetUpdatesSinceCalls
+	BlockCacheCompressedHit
+	BlockCacheCompressedAdd
+	BlockCacheCompressedAddFailures
+	WalFileSynced
+	WalFileBytes
+	WriteDoneBySelf
+	WriteDoneByOthers
+	WriteTimeout
+	WriteWithWal
+	CompactReadBytes
+	CompactWriteBytes
+	FlushWriteBytes
+	NumberDirectLoadTableProperties
+	NumberSuperversionAcquires
+	NumberSuperversionReleases
+	NumberSuperversionCleanups
+	NumberBlockCompressed
+	NumberBlockDecompressed
+	NumberBlockNotCompressed
+	MergeOperationTotalTime
+	FilterOperationTotalTime
+	RowCacheHit
+	RowCacheMiss
+	ReadAmpEstimateUsefulBytes
+	ReadAmpTotalReadBytes
+	NumberRateLimiterDrains
+	NumberIterSkip
+	BlobDbNumPut
+	BlobDbNumWrite
+	BlobDbNumGet
+	BobDbNumMultiget
+	BlobDbNumSeek
+	BlobDbNumNext
+	BlobDbNumPrev
+	BlobDbNumKeysWritten
+	BlobDbNumKeysRead
+	BlobDbBytesWritten
+	BlobDbBytesRead
+	BlobDbWriteInlined
+	BlobDbWriteInlinedTtl
+	BlobDbWriteBlob
+	BlobDbWriteBlobTtl
+	BlobDbBlobFileBytesWritten
+	BlobDbBlobFileBytesRead
+	BlobDbBlobFileSynced
+	BlobDbBlobInlineExpiredCount
+	BlobDbBlobIndexExpiredSize
+	BlobDbBlobIndexEvictedCount
+	BlobDbBlobIndexEvictedSize
+	BlobDbGcNumFiles
+	BlobDbGcFailures
+	BlobDbGcNumKeysOverwritten
+	BlobDbGcNumKeysExpired
+	BlobDbGcNumKeysRelocated
+	BlobDbGcBytesOverwritten
+	BlobDbGcBytesExpired
+	BlobDbGcBytesRelocated
+	BlobDbFifoNumFilesEvicted
+	BlobDbFifoNumKeysEvicted
+	BlobDbFifoBytesEvicted
+    TxnPrepareMutexOverhead
+	TxnOldCommitMapMutexOverhead
+	TxnDuplicateKeyOverhead
+	TxnSnapshotMutexOverhead
+	NumberMultigetKeysFound
+	NoIteratorCreated
+	NoIteratorDeleted
+	BlockCacheCompressionDictMiss
+	BlockCacheCompressionDictHit
+	BlockCacheCompressionDictAdd
+	BlockCacheCompressionDictBytesInsert
+	BlockCacheCompressionDictBytesEvict
+	BlockCacheAddRedundant
+	BlockCacheIndexAddRedundant
+	BlockCacheFilterAddRedundant
+	BlockCacheDataAddRedundant
+	BlockCacheCompressionDictAddRedundant
+	FilesMarkedTrash
+	FilesDeletedImmediately
+	TickerMax
+)
+
+type StatsLevel byte
+
+const (
+	StatsExceptHistogramOrTimers = StatsLevel(0)
+	StatsExceptTimers
+	StatsExceptDetailedTimers
+	StatsExceptTimeForMutex
+	StatsAll
+)
+
+
 // Options represent all of the available options when opening a database with Open.
 type Options struct {
 	c *C.rocksdb_options_t
@@ -1210,4 +1374,26 @@ func (opts *Options) Destroy() {
 	opts.c = nil
 	opts.env = nil
 	opts.bbto = nil
+}
+
+// GetTickerCount
+func (opts *Options) GetTickerCount(ticker Ticker) uint64 {
+	retval, _ := C.gorocksdb_get_ticker_count(opts.c, C.uint(ticker))
+
+	return uint64(retval)
+}
+
+func (opts *Options) GetAndResetTickerCount(ticker Ticker) uint64 {
+	retval, _ := C.gorocksdb_get_and_reset_ticker_count(opts.c, C.uint(ticker))
+
+	return uint64(retval)
+}
+
+func (opts *Options) SetStatsLevel(sl StatsLevel) {
+	C.gorocksdb_set_stats_level(opts.c, C.uchar(sl))
+}
+
+func (opts *Options) GetStatsLevel() StatsLevel {
+	ret := C.gorocksdb_get_stats_level(opts.c)
+    return StatsLevel(ret)
 }

--- a/options.go
+++ b/options.go
@@ -74,7 +74,7 @@ type Ticker uint32
 // Options for use in GetTickerCount and GetAndResetTickerCount
 // For definitions of individual flags, see <rocksdb/statistics.h>
 const (
-	BlockCacheMiss             = Ticker(0)
+	BlockCacheMiss             = Ticker(iota)
 	BlockCacheHit
 	BlockCacheAdd
 	BlockCacheAddFailures
@@ -1376,24 +1376,33 @@ func (opts *Options) Destroy() {
 	opts.bbto = nil
 }
 
-// GetTickerCount
+// GetTickerCount gets the current value of Ticker
 func (opts *Options) GetTickerCount(ticker Ticker) uint64 {
-	retval, _ := C.gorocksdb_get_ticker_count(opts.c, C.uint(ticker))
+	retval, _ := C.rocksdb_get_ticker_count(opts.c, C.uint(ticker))
 
 	return uint64(retval)
 }
 
+// GetAndResetTickerCount gets the current value of Ticker, and resets it to zero
 func (opts *Options) GetAndResetTickerCount(ticker Ticker) uint64 {
-	retval, _ := C.gorocksdb_get_and_reset_ticker_count(opts.c, C.uint(ticker))
+	retval, _ := C.rocksdb_get_and_reset_ticker_count(opts.c, C.uint(ticker))
 
 	return uint64(retval)
+}
+
+func (opts *Options) RecordTick(ticker Ticker, count uint64) {
+	C.rocksdb_record_tick(opts.c, C.uint(ticker), C.ulonglong(count))
+}
+
+func (opts *Options) SetTickerCount(ticker Ticker, count uint64) {
+	C.rocksdb_set_ticker_count(opts.c, C.uint(ticker), C.ulonglong(count))
 }
 
 func (opts *Options) SetStatsLevel(sl StatsLevel) {
-	C.gorocksdb_set_stats_level(opts.c, C.uchar(sl))
+	C.rocksdb_set_stats_level(opts.c, C.uchar(sl))
 }
 
 func (opts *Options) GetStatsLevel() StatsLevel {
-	ret := C.gorocksdb_get_stats_level(opts.c)
+	ret := C.rocksdb_get_stats_level(opts.c)
     return StatsLevel(ret)
 }

--- a/options.go
+++ b/options.go
@@ -225,7 +225,7 @@ const (
 type StatsLevel byte
 
 const (
-	StatsExceptHistogramOrTimers = StatsLevel(0)
+	StatsExceptHistogramOrTimers = StatsLevel(iota)
 	StatsExceptTimers
 	StatsExceptDetailedTimers
 	StatsExceptTimeForMutex
@@ -1390,18 +1390,22 @@ func (opts *Options) GetAndResetTickerCount(ticker Ticker) uint64 {
 	return uint64(retval)
 }
 
+// RecordTick adds count to the specified ticker
 func (opts *Options) RecordTick(ticker Ticker, count uint64) {
 	C.rocksdb_record_tick(opts.c, C.uint(ticker), C.ulonglong(count))
 }
 
+// SetTickerCount sets the current ticker count.
 func (opts *Options) SetTickerCount(ticker Ticker, count uint64) {
 	C.rocksdb_set_ticker_count(opts.c, C.uint(ticker), C.ulonglong(count))
 }
 
+// SetStatsLevel sets the current statistics logging level - See <rocksdb/statistics.h> for more information
 func (opts *Options) SetStatsLevel(sl StatsLevel) {
 	C.rocksdb_set_stats_level(opts.c, C.uchar(sl))
 }
 
+// GetStatsLevel retrieves the current statistics logging level - See <rocksdb/statistics.h> for more information
 func (opts *Options) GetStatsLevel() StatsLevel {
 	ret := C.rocksdb_get_stats_level(opts.c)
     return StatsLevel(ret)

--- a/options_block_based_table.go
+++ b/options_block_based_table.go
@@ -235,3 +235,9 @@ func (opts *BlockBasedTableOptions) SetFormatVersion(version int) {
 func (opts *BlockBasedTableOptions) SetIndexType(value IndexType) {
 	C.rocksdb_block_based_options_set_index_type(opts.c, C.int(value))
 }
+
+// SetFlushEveryBlockPolicy sets the table to perform a flush after inserting each key.  Useful for
+// testing only.
+func (opts *BlockBasedTableOptions) SetFlushEveryKeyPolicy() {
+	C.rocksdb_block_based_options_set_flush_every_key_policy(opts.c)
+}

--- a/staticflag_linux.go
+++ b/staticflag_linux.go
@@ -3,4 +3,5 @@
 package gorocksdb
 
 // #cgo LDFLAGS: -l:librocksdb.a -l:libstdc++.a -l:libz.a -l:libbz2.a -l:libsnappy.a -l:liblz4.a -l:libzstd.a -lm -ldl
+// #cgo CXXFLAGS: --std=c++11
 import "C"

--- a/statistics.cpp
+++ b/statistics.cpp
@@ -1,0 +1,27 @@
+#include "rocksdb/c.h"
+#include "rocksdb/options.h"
+#include "rocksdb/statistics.h"
+
+using rocksdb::Options;
+using rocksdb::Tickers;
+
+extern "C" {
+struct rocksdb_options_t { Options rep; };
+
+uint64_t gorocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
+    return options->rep.statistics->getTickerCount(ticker);
+}
+
+uint64_t gorocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
+    return options->rep.statistics->getAndResetTickerCount(ticker);
+}
+
+void gorocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level) {
+    options->rep.statistics->set_stats_level((rocksdb::StatsLevel)level);
+}
+
+uint8_t gorocksdb_get_stats_level(rocksdb_options_t *options) {
+    return options->rep.statistics->get_stats_level();
+}
+
+}

--- a/statistics.cpp
+++ b/statistics.cpp
@@ -1,27 +1,75 @@
 #include "rocksdb/c.h"
 #include "rocksdb/options.h"
 #include "rocksdb/statistics.h"
+#include "rocksdb/flush_block_policy.h"
 
 using rocksdb::Options;
 using rocksdb::Tickers;
 
-extern "C" {
-struct rocksdb_options_t { Options rep; };
+using namespace rocksdb;
 
-uint64_t gorocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
+class FlushBlockEveryKeyPolicy : public FlushBlockPolicy {
+ public:
+  bool Update(const Slice& /*key*/, const Slice& /*value*/) override {
+    if (!start_) {
+      start_ = true;
+      return false;
+    }
+    return true;
+  }
+
+ private:
+  bool start_ = false;
+};
+
+class FlushBlockEveryKeyPolicyFactory : public FlushBlockPolicyFactory {
+ public:
+  explicit FlushBlockEveryKeyPolicyFactory() {}
+
+  const char* Name() const override {
+    return "FlushBlockEveryKeyPolicyFactory";
+  }
+
+  FlushBlockPolicy* NewFlushBlockPolicy(
+      const BlockBasedTableOptions& /*table_options*/,
+      const BlockBuilder& /*data_block_builder*/) const override {
+    return new FlushBlockEveryKeyPolicy;
+  }
+};
+
+
+extern "C" {
+
+struct rocksdb_options_t { Options rep; };
+struct rocksdb_block_based_table_options_t { BlockBasedTableOptions rep; };
+
+uint64_t rocksdb_get_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
     return options->rep.statistics->getTickerCount(ticker);
 }
 
-uint64_t gorocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
+uint64_t rocksdb_get_and_reset_ticker_count(rocksdb_options_t *options, uint32_t ticker) {
     return options->rep.statistics->getAndResetTickerCount(ticker);
 }
 
-void gorocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level) {
+void rocksdb_record_tick(rocksdb_options_t *options, uint32_t ticker, uint64_t count) {
+    options->rep.statistics->recordTick(ticker, count);
+}
+
+void rocksdb_set_ticker_count(rocksdb_options_t *options, uint32_t ticker, uint64_t count) {
+    options->rep.statistics->recordTick(ticker, count);
+}
+
+void rocksdb_set_stats_level(rocksdb_options_t *options, uint8_t level) {
     options->rep.statistics->set_stats_level((rocksdb::StatsLevel)level);
 }
 
-uint8_t gorocksdb_get_stats_level(rocksdb_options_t *options) {
+uint8_t rocksdb_get_stats_level(rocksdb_options_t *options) {
     return options->rep.statistics->get_stats_level();
 }
+
+void rocksdb_block_based_options_set_flush_every_key_policy(rocksdb_block_based_table_options_t *opts) {
+    opts->rep.flush_block_policy_factory = std::make_shared<FlushBlockEveryKeyPolicyFactory>();
+}
+
 
 }

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -1,0 +1,134 @@
+package gorocksdb
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"testing"
+)
+
+type stringMerge struct {
+}
+
+func (sm stringMerge) FullMerge(key, existingValue []byte, operands [][]byte) ([]byte, bool) {
+	ret := []byte{}
+	if existingValue != nil {
+		ret = append(existingValue, ',')
+		if len(operands) >= 1 {
+			ret = append(ret, operands[0]...)
+		}
+	} else {
+		if len(operands) >= 1 {
+			ret = operands[0]
+		}
+	}
+
+	for _, op := range operands[1:] {
+		ret = append(ret, ',')
+		ret = append(ret, op...)
+	}
+	return ret, true
+}
+
+func (sm stringMerge) Name() string {
+	return "StringMerge"
+}
+
+func TestStatistics(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	dir, err := ioutil.TempDir("/tmp", "gorocksdb-TestStatistics")
+	assert.NoError(err, "Could not create temp directory")
+
+	opts := NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+	mergeOpt := stringMerge{}
+	opts.SetMergeOperator(mergeOpt)
+	opts.EnableStatistics()
+	opts.SetStatsLevel(StatsExceptDetailedTimers)
+
+	cache := NewLRUCache(1000)
+	bbto := NewDefaultBlockBasedTableOptions()
+	bbto.SetBlockCache(cache)
+	bbto.SetFlushEveryKeyPolicy()
+	opts.SetBlockBasedTableFactory(bbto)
+	bbto.SetIndexType(KBinarySearchIndexType)
+
+	db, err := OpenDb(opts, dir)
+	assert.NoError(err, "Unable to open database")
+	assert.NotNil(db, "Unable to open database")
+
+	ro := NewDefaultReadOptions()
+	ro.SetFillCache(true)
+
+	wo := NewDefaultWriteOptions()
+	fo := NewDefaultFlushOptions()
+
+	assert.NoError(db.Merge(wo, []byte("a1"), []byte("x1")), "Unable to Merge a1/x1")
+	assert.NoError(db.Merge(wo, []byte("b1"), []byte("y1")), "Unable to Merge b1/y1")
+	assert.NoError(db.Merge(wo, []byte("c1"), []byte("z1")), "Unable to Merge c1/z1")
+	assert.NoError(db.Flush(fo), "Unable to db.Flush()")
+
+	assert.NoError(db.Merge(wo, []byte("a2"), []byte("x2")), "Unable to Merge a2/x2")
+	assert.NoError(db.Merge(wo, []byte("b2"), []byte("y2")), "Unable to Merge b2/y2")
+	assert.NoError(db.Merge(wo, []byte("c2"), []byte("z2")), "Unable to Merge c2/z2")
+	assert.NoError(db.Flush(fo), "Unable to db.Flush()")
+
+	assert.NoError(db.Merge(wo, []byte("a3"), []byte("x3")), "Unable to Merge a3/x3")
+	assert.NoError(db.Merge(wo, []byte("b3"), []byte("y3")), "Unable to Merge b3/y3")
+	assert.NoError(db.Merge(wo, []byte("c3"), []byte("z3")), "Unable to Merge c3/z3")
+	assert.NoError(db.Flush(fo), "Unable to db.Flush()")
+
+	it := db.NewIterator(ro)
+	assert.NotNil(it, "Unable to create iterator")
+
+	opts.SetTickerCount(BlockCacheMiss, 0)
+	opts.SetTickerCount(BlockCacheHit, 0)
+
+	it.Seek([]byte("b2"))
+	assert.True(it.Valid(), "Failed iterator seek")
+	assert.Equal("b2", string(it.Key().Data()), "Incorrect key found")
+	assert.Equal("y2", string(it.Value().Data()), "Incorrect value found")
+	assert.Equal(uint64(5), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataMiss), "Incorrect block data miss count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataHit), "Incorrect block data hit count")
+
+	it.Seek([]byte("a2"))
+	assert.True(it.Valid(), "Failed iterator seek")
+	assert.Equal("a2", string(it.Key().Data()), "Incorrect key found")
+	assert.Equal("x2", string(it.Value().Data()), "Incorrect value found")
+	assert.Equal(uint64(8), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(2), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataMiss), "Incorrect block data miss count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataHit), "Incorrect block data hit count")
+
+	it.Seek([]byte("c2"))
+	assert.True(it.Valid(), "Failed iterator seek")
+	assert.Equal("c2", string(it.Key().Data()), "Incorrect key found")
+	assert.Equal("z2", string(it.Value().Data()), "Incorrect value found")
+	assert.Equal(uint64(9), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(3), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+
+	it.Seek([]byte("a1"))
+	assert.True(it.Valid(), "Failed iterator seek")
+	assert.Equal("a1", string(it.Key().Data()), "Incorrect key found")
+	assert.Equal("x1", string(it.Value().Data()), "Incorrect value found")
+	assert.Equal(uint64(9), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(7), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+
+	it.Seek([]byte("a3"))
+	assert.True(it.Valid(), "Failed iterator seek")
+	assert.Equal("a3", string(it.Key().Data()), "Incorrect key found")
+	assert.Equal("x3", string(it.Value().Data()), "Incorrect value found")
+	assert.Equal(uint64(9), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(11), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+
+	misses := opts.GetAndResetTickerCount(BlockCacheMiss)
+	hits := opts.GetAndResetTickerCount(BlockCacheHit)
+
+	assert.Equal(uint64(9), misses, "Incorrect block miss count")
+	assert.Equal(uint64(11), hits, "Incorrect block hit count")
+
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
+	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
+}

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -90,8 +90,6 @@ func TestStatistics(t *testing.T) {
 	assert.Equal("y2", string(it.Value().Data()), "Incorrect value found")
 	assert.Equal(uint64(5), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
 	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
-	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataMiss), "Incorrect block data miss count")
-	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataHit), "Incorrect block data hit count")
 
 	it.Seek([]byte("a2"))
 	assert.True(it.Valid(), "Failed iterator seek")
@@ -99,8 +97,6 @@ func TestStatistics(t *testing.T) {
 	assert.Equal("x2", string(it.Value().Data()), "Incorrect value found")
 	assert.Equal(uint64(8), opts.GetTickerCount(BlockCacheMiss), "Incorrect block miss count")
 	assert.Equal(uint64(2), opts.GetTickerCount(BlockCacheHit), "Incorrect block hit count")
-	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataMiss), "Incorrect block data miss count")
-	assert.Equal(uint64(0), opts.GetTickerCount(BlockCacheDataHit), "Incorrect block data hit count")
 
 	it.Seek([]byte("c2"))
 	assert.True(it.Valid(), "Failed iterator seek")


### PR DESCRIPTION
This adds in Go hooks to access the Tickers within the rocksdb Options class (technically Statistics class within options).  The primary motivation for this is to evaluate the block cache hit/miss rates within RocksDB.   We can then use this information to make an informed decision on sizing the RocksDB cache versus the go fastcache we have sitting in front of some of our RocksDB databases.