### PR TITLE
Add GetPinnedCF method

### DIFF
--- a/options.go
+++ b/options.go
@@ -118,6 +118,11 @@ func GetOptionsFromString(base *Options, optStr string) (*Options, error) {
 	return newOpt, nil
 }
 
+// UnsafeGetOptions returns the underlying c options.
+func (opts *Options) UnsafeGetOptions() unsafe.Pointer {
+	return unsafe.Pointer(opts.c)
+}
+
 // -------------------
 // Parameters that affect behavior
 


### PR DESCRIPTION
This PR adds:
1. The column family variation of the `GetPinned` method
2. An "UnsafeGet" method for DB options.