### PR TITLE
Change minimum required RocksDB version to 6.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Install
 
-You'll need to build [RocksDB](https://github.com/facebook/rocksdb) v5.16+ on your machine.
+You'll need to build [RocksDB](https://github.com/facebook/rocksdb) v6.16+ on your machine.
 
 After that, you can install gorocksdb using the following command:
 
@@ -14,5 +14,3 @@ After that, you can install gorocksdb using the following command:
 
 Please note that this package might upgrade the required RocksDB version at any moment.
 Vendoring is thus highly recommended if you require high stability.
-
-*The [embedded CockroachDB RocksDB](https://github.com/cockroachdb/c-rocksdb) is no longer supported in gorocksdb.*

--- a/db.go
+++ b/db.go
@@ -582,10 +582,10 @@ func (db *DB) DropColumnFamily(c *ColumnFamilyHandle) error {
 //
 // The keys counted will begin at Range.Start and end on the key before
 // Range.Limit.
-func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
+func (db *DB) GetApproximateSizes(ranges []Range) ([]uint64, error) {
 	sizes := make([]uint64, len(ranges))
 	if len(ranges) == 0 {
-		return sizes
+		return sizes, nil
 	}
 
 	cStarts := make([]*C.char, len(ranges))
@@ -606,6 +606,7 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 		}
 	}()
 
+	var cErr *C.char
 	C.rocksdb_approximate_sizes(
 		db.c,
 		C.int(len(ranges)),
@@ -613,9 +614,15 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 		&cStartLens[0],
 		&cLimits[0],
 		&cLimitLens[0],
-		(*C.uint64_t)(&sizes[0]))
+		(*C.uint64_t)(&sizes[0]),
+		&cErr,
+	)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return sizes, errors.New(C.GoString(cErr))
+	}
 
-	return sizes
+	return sizes, nil
 }
 
 // GetApproximateSizesCF returns the approximate number of bytes of file system
@@ -623,10 +630,10 @@ func (db *DB) GetApproximateSizes(ranges []Range) []uint64 {
 //
 // The keys counted will begin at Range.Start and end on the key before
 // Range.Limit.
-func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) []uint64 {
+func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) ([]uint64, error) {
 	sizes := make([]uint64, len(ranges))
 	if len(ranges) == 0 {
-		return sizes
+		return sizes, nil
 	}
 
 	cStarts := make([]*C.char, len(ranges))
@@ -647,6 +654,7 @@ func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) []ui
 		}
 	}()
 
+	var cErr *C.char
 	C.rocksdb_approximate_sizes_cf(
 		db.c,
 		cf.c,
@@ -655,9 +663,14 @@ func (db *DB) GetApproximateSizesCF(cf *ColumnFamilyHandle, ranges []Range) []ui
 		&cStartLens[0],
 		&cLimits[0],
 		&cLimitLens[0],
-		(*C.uint64_t)(&sizes[0]))
-
-	return sizes
+		(*C.uint64_t)(&sizes[0]),
+		&cErr,
+	)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return sizes, errors.New(C.GoString(cErr))
+	}
+	return sizes, nil
 }
 
 // SetOptions dynamically changes options through the SetOptions API.
@@ -761,7 +774,7 @@ func (db *DB) FlushCF(cf *ColumnFamilyHandle, opts *FlushOptions) error {
 		return errors.New(C.GoString(cErr))
 	}
 	return nil
-} 
+}
 
 // DisableFileDeletions disables file deletions and should be used when backup the database.
 func (db *DB) DisableFileDeletions() error {

--- a/db_test.go
+++ b/db_test.go
@@ -210,16 +210,19 @@ func TestDBGetApproximateSizes(t *testing.T) {
 	defer db.Close()
 
 	// no ranges
-	sizes := db.GetApproximateSizes(nil)
+	sizes, err := db.GetApproximateSizes(nil)
 	ensure.DeepEqual(t, len(sizes), 0)
+	ensure.Nil(t, err)
 
 	// range will nil start and limit
-	sizes = db.GetApproximateSizes([]Range{{Start: nil, Limit: nil}})
+	sizes, err = db.GetApproximateSizes([]Range{{Start: nil, Limit: nil}})
 	ensure.DeepEqual(t, sizes, []uint64{0})
+	ensure.Nil(t, err)
 
 	// valid range
-	sizes = db.GetApproximateSizes([]Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
+	sizes, err = db.GetApproximateSizes([]Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
 	ensure.DeepEqual(t, sizes, []uint64{0})
+	ensure.Nil(t, err)
 }
 
 func TestDBGetApproximateSizesCF(t *testing.T) {
@@ -232,16 +235,19 @@ func TestDBGetApproximateSizesCF(t *testing.T) {
 	ensure.Nil(t, err)
 
 	// no ranges
-	sizes := db.GetApproximateSizesCF(cf, nil)
+	sizes, err := db.GetApproximateSizesCF(cf, nil)
 	ensure.DeepEqual(t, len(sizes), 0)
+	ensure.Nil(t, err)
 
 	// range will nil start and limit
-	sizes = db.GetApproximateSizesCF(cf, []Range{{Start: nil, Limit: nil}})
+	sizes, err = db.GetApproximateSizesCF(cf, []Range{{Start: nil, Limit: nil}})
 	ensure.DeepEqual(t, sizes, []uint64{0})
+	ensure.Nil(t, err)
 
 	// valid range
-	sizes = db.GetApproximateSizesCF(cf, []Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
+	sizes, err = db.GetApproximateSizesCF(cf, []Range{{Start: []byte{0x00}, Limit: []byte{0xFF}}})
 	ensure.DeepEqual(t, sizes, []uint64{0})
+	ensure.Nil(t, err)
 }
 
 func TestDBFlushCF(t *testing.T) {

--- a/memory_usage_test.go
+++ b/memory_usage_test.go
@@ -14,6 +14,7 @@ func TestMemoryUsage(t *testing.T) {
 	cache := NewLRUCache(8 * 1024 * 1024)
 	bbto := NewDefaultBlockBasedTableOptions()
 	bbto.SetBlockCache(cache)
+	defer bbto.Destroy()
 	defer cache.Destroy()
 
 	applyOpts := func(opts *Options) {
@@ -40,6 +41,11 @@ func TestMemoryUsage(t *testing.T) {
 
 	err = db.Put(wo, key, value)
 	ensure.Nil(t, err)
+
+	// A single Put is not enough to increase approximate memtable usage.
+	err = db.Put(wo, key, value)
+	ensure.Nil(t, err)
+
 	_, err = db.Get(ro, key)
 	ensure.Nil(t, err)
 


### PR DESCRIPTION
RocksDB 6.16 changed the signatures of `rocksdb_approximate_sizes` and `rocksdb_approximate_sizes_cf`.

Our fork already required RocksDB 6+ to build - it uses some APIs available only in newer versions. 