### PR TITLE
Allow usage of GetApproximateMemoryUsageByType with TransactionDB

### DIFF
--- a/memory_usage.go
+++ b/memory_usage.go
@@ -20,38 +20,38 @@ type MemoryUsage struct {
 	CacheTotal uint64
 }
 
-type DBForMemoryUsage interface {
-	getDBforMemoryUsage() *C.rocksdb_t
+type NativeDB interface {
+	getNativeDB() *C.rocksdb_t
 }
 
-func (db *DB) getDBforMemoryUsage() *C.rocksdb_t {
+func (db *DB) getNativeDB() *C.rocksdb_t {
 	return db.c
 }
 
-func (db *TransactionDB) getDBforMemoryUsage() *C.rocksdb_t {
+func (db *TransactionDB) getNativeDB() *C.rocksdb_t {
 	return (*C.rocksdb_t)(db.c)
 }
 
 // GetApproximateMemoryUsageByType returns summary
 // memory usage stats for given databases and caches.
 func GetApproximateMemoryUsageByType(dbs []*DB, caches []*Cache) (*MemoryUsage, error) {
-	dbsForMemoryUsage := make([]DBForMemoryUsage, 0, len(dbs))
+	dbsForMemoryUsage := make([]NativeDB, 0, len(dbs))
 	for _, db := range dbs {
 		dbsForMemoryUsage = append(dbsForMemoryUsage, db)
 	}
-	return GetApproximateMemoryUsageByTypeGenericDB(dbsForMemoryUsage, caches)
+	return GetApproximateMemoryUsageByTypeNativeDB(dbsForMemoryUsage, caches)
 }
 
-// GetApproximateMemoryUsageByTypeGenericDB returns summary
+// GetApproximateMemoryUsageByTypeNativeDB returns summary
 // memory usage stats for given databases and caches.
-func GetApproximateMemoryUsageByTypeGenericDB(dbs []DBForMemoryUsage, caches []*Cache) (*MemoryUsage, error) {
+func GetApproximateMemoryUsageByTypeNativeDB(dbs []NativeDB, caches []*Cache) (*MemoryUsage, error) {
 	// register memory consumers
 	consumers := C.rocksdb_memory_consumers_create()
 	defer C.rocksdb_memory_consumers_destroy(consumers)
 
 	for _, db := range dbs {
 		if db != nil {
-			C.rocksdb_memory_consumers_add_db(consumers, (db.getDBforMemoryUsage()))
+			C.rocksdb_memory_consumers_add_db(consumers, (db.getNativeDB()))
 		}
 	}
 	for _, cache := range caches {

--- a/memory_usage.go
+++ b/memory_usage.go
@@ -20,16 +20,28 @@ type MemoryUsage struct {
 	CacheTotal uint64
 }
 
+type DBForMemoryUsage interface {
+	getDBforMemoryUsage() *C.rocksdb_t
+}
+
+func (db *DB) getDBforMemoryUsage() *C.rocksdb_t {
+	return db.c
+}
+
+func (db *TransactionDB) getDBforMemoryUsage() *C.rocksdb_t {
+	return (*C.rocksdb_t)(db.c)
+}
+
 // GetApproximateMemoryUsageByType returns summary
 // memory usage stats for given databases and caches.
-func GetApproximateMemoryUsageByType(dbs []*DB, caches []*Cache) (*MemoryUsage, error) {
+func GetApproximateMemoryUsageByType(dbs []DBForMemoryUsage, caches []*Cache) (*MemoryUsage, error) {
 	// register memory consumers
 	consumers := C.rocksdb_memory_consumers_create()
 	defer C.rocksdb_memory_consumers_destroy(consumers)
 
 	for _, db := range dbs {
 		if db != nil {
-			C.rocksdb_memory_consumers_add_db(consumers, db.c)
+			C.rocksdb_memory_consumers_add_db(consumers, (db.getDBforMemoryUsage()))
 		}
 	}
 	for _, cache := range caches {

--- a/memory_usage.go
+++ b/memory_usage.go
@@ -35,11 +35,11 @@ func (db *TransactionDB) getNativeDB() *C.rocksdb_t {
 // GetApproximateMemoryUsageByType returns summary
 // memory usage stats for given databases and caches.
 func GetApproximateMemoryUsageByType(dbs []*DB, caches []*Cache) (*MemoryUsage, error) {
-	dbsForMemoryUsage := make([]NativeDB, 0, len(dbs))
+	nativeDBs := make([]NativeDB, 0, len(dbs))
 	for _, db := range dbs {
-		dbsForMemoryUsage = append(dbsForMemoryUsage, db)
+		nativeDBs = append(nativeDBs, db)
 	}
-	return GetApproximateMemoryUsageByTypeNativeDB(dbsForMemoryUsage, caches)
+	return GetApproximateMemoryUsageByTypeNativeDB(nativeDBs, caches)
 }
 
 // GetApproximateMemoryUsageByTypeNativeDB returns summary

--- a/memory_usage.go
+++ b/memory_usage.go
@@ -34,7 +34,17 @@ func (db *TransactionDB) getDBforMemoryUsage() *C.rocksdb_t {
 
 // GetApproximateMemoryUsageByType returns summary
 // memory usage stats for given databases and caches.
-func GetApproximateMemoryUsageByType(dbs []DBForMemoryUsage, caches []*Cache) (*MemoryUsage, error) {
+func GetApproximateMemoryUsageByType(dbs []*DB, caches []*Cache) (*MemoryUsage, error) {
+	dbsForMemoryUsage := make([]DBForMemoryUsage, 0, len(dbs))
+	for _, db := range dbs {
+		dbsForMemoryUsage = append(dbsForMemoryUsage, db)
+	}
+	return GetApproximateMemoryUsageByTypeGenericDB(dbsForMemoryUsage, caches)
+}
+
+// GetApproximateMemoryUsageByTypeGenericDB returns summary
+// memory usage stats for given databases and caches.
+func GetApproximateMemoryUsageByTypeGenericDB(dbs []DBForMemoryUsage, caches []*Cache) (*MemoryUsage, error) {
 	// register memory consumers
 	consumers := C.rocksdb_memory_consumers_create()
 	defer C.rocksdb_memory_consumers_destroy(consumers)

--- a/memory_usage_test.go
+++ b/memory_usage_test.go
@@ -25,7 +25,7 @@ func TestMemoryUsage(t *testing.T) {
 	defer db.Close()
 
 	// take first memory usage snapshot
-	mu1, err := GetApproximateMemoryUsageByType([]*DB{db}, []*Cache{cache})
+	mu1, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// perform IO operations that will affect in-memory tables (and maybe cache as well)
@@ -50,7 +50,59 @@ func TestMemoryUsage(t *testing.T) {
 	ensure.Nil(t, err)
 
 	// take second memory usage snapshot
-	mu2, err := GetApproximateMemoryUsageByType([]*DB{db}, []*Cache{cache})
+	mu2, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	ensure.Nil(t, err)
+
+	// the amount of memory used by memtables should increase after write/read;
+	// cache memory usage is not likely to be changed, perhaps because requested key is kept by memtable
+	assert.True(t, mu2.MemTableTotal > mu1.MemTableTotal)
+	assert.True(t, mu2.MemTableUnflushed > mu1.MemTableUnflushed)
+	assert.True(t, mu2.CacheTotal >= mu1.CacheTotal)
+	assert.True(t, mu2.MemTableReadersTotal >= mu1.MemTableReadersTotal)
+}
+
+func TestMemoryUsageTransactionDB(t *testing.T) {
+	// create database with cache
+	cache := NewLRUCache(8 * 1024 * 1024)
+	bbto := NewDefaultBlockBasedTableOptions()
+	bbto.SetBlockCache(cache)
+	defer bbto.Destroy()
+	defer cache.Destroy()
+
+	applyOpts := func(opts *Options, transactionDBOpts *TransactionDBOptions) {
+		opts.SetBlockBasedTableFactory(bbto)
+	}
+
+	db := newTestTransactionDB(t, "TestMemoryUsage", applyOpts)
+	defer db.Close()
+
+	// take first memory usage snapshot
+	mu1, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	ensure.Nil(t, err)
+
+	// perforx`m IO operations that will affect in-memory tables (and maybe cache as well)
+	wo := NewDefaultWriteOptions()
+	defer wo.Destroy()
+	ro := NewDefaultReadOptions()
+	defer ro.Destroy()
+
+	key := []byte("key")
+	value := make([]byte, 1024)
+	_, err = rand.Read(value)
+	ensure.Nil(t, err)
+
+	err = db.Put(wo, key, value)
+	ensure.Nil(t, err)
+
+	// A single Put is not enough to increase approximate memtable usage.
+	err = db.Put(wo, key, value)
+	ensure.Nil(t, err)
+
+	_, err = db.Get(ro, key)
+	ensure.Nil(t, err)
+
+	// take second memory usage snapshot
+	mu2, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// the amount of memory used by memtables should increase after write/read;

--- a/memory_usage_test.go
+++ b/memory_usage_test.go
@@ -77,7 +77,7 @@ func TestMemoryUsageTransactionDB(t *testing.T) {
 	defer db.Close()
 
 	// take first memory usage snapshot
-	mu1, err := GetApproximateMemoryUsageByTypeGenericDB([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu1, err := GetApproximateMemoryUsageByTypeNativeDB([]NativeDB{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// perforx`m IO operations that will affect in-memory tables (and maybe cache as well)
@@ -102,7 +102,7 @@ func TestMemoryUsageTransactionDB(t *testing.T) {
 	ensure.Nil(t, err)
 
 	// take second memory usage snapshot
-	mu2, err := GetApproximateMemoryUsageByTypeGenericDB([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu2, err := GetApproximateMemoryUsageByTypeNativeDB([]NativeDB{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// the amount of memory used by memtables should increase after write/read;

--- a/memory_usage_test.go
+++ b/memory_usage_test.go
@@ -25,7 +25,7 @@ func TestMemoryUsage(t *testing.T) {
 	defer db.Close()
 
 	// take first memory usage snapshot
-	mu1, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu1, err := GetApproximateMemoryUsageByType([]*DB{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// perform IO operations that will affect in-memory tables (and maybe cache as well)
@@ -50,7 +50,7 @@ func TestMemoryUsage(t *testing.T) {
 	ensure.Nil(t, err)
 
 	// take second memory usage snapshot
-	mu2, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu2, err := GetApproximateMemoryUsageByType([]*DB{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// the amount of memory used by memtables should increase after write/read;
@@ -77,7 +77,7 @@ func TestMemoryUsageTransactionDB(t *testing.T) {
 	defer db.Close()
 
 	// take first memory usage snapshot
-	mu1, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu1, err := GetApproximateMemoryUsageByTypeGenericDB([]DBForMemoryUsage{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// perforx`m IO operations that will affect in-memory tables (and maybe cache as well)
@@ -102,7 +102,7 @@ func TestMemoryUsageTransactionDB(t *testing.T) {
 	ensure.Nil(t, err)
 
 	// take second memory usage snapshot
-	mu2, err := GetApproximateMemoryUsageByType([]DBForMemoryUsage{db}, []*Cache{cache})
+	mu2, err := GetApproximateMemoryUsageByTypeGenericDB([]DBForMemoryUsage{db}, []*Cache{cache})
 	ensure.Nil(t, err)
 
 	// the amount of memory used by memtables should increase after write/read;


### PR DESCRIPTION
Change `GetApproximateMemoryUsageByType` to accept the new `DBForMemoryUsage` interface common to `DB` and `TransactionDB` to be able to use this function with `TransactionDB` objects.


## Why is this needed?

`GetApproximateMemoryUsageByType` is a very useful function to get memory usage stats. It only accepts plaine `DB` instances while it is possible to use it with all db types in the upstream C++ version:
https://github.com/facebook/rocksdb/blob/2926e0718c479c5852f3bca7a4ff8c48b69afbbd/utilities/memory/memory_util.cc#L13

`TransactionDB` being a subclass of `DB` through `StackableDB`.

https://github.com/facebook/rocksdb/blob/2926e0718c479c5852f3bca7a4ff8c48b69afbbd/include/rocksdb/utilities/transaction_db.h#L373
https://github.com/facebook/rocksdb/blob/2926e0718c479c5852f3bca7a4ff8c48b69afbbd/include/rocksdb/utilities/stackable_db.h#L21


## Why is this ugly

The C API only exposes functions to get the memory usage of a regular db (`rocksdb_t`):
https://github.com/facebook/rocksdb/blob/05a1d52e77f5b98791849aae83bad413f2e42601/include/rocksdb/c.h#L2821-L2833
Although in the native C++ code, a TransactionDB is actually a subclass of a base `DB`, in the C API it is not possible to convert it. It is possible to convert a optimistictransactiondb thought which is very frustrating! https://github.com/facebook/rocksdb/blob/05a1d52e77f5b98791849aae83bad413f2e42601/include/rocksdb/c.h#L2711-L2713


So this change essentially cast the `rocksdb_transactiondb_t` pointer to a `rocksdb_t` pointer which should be incorrect and result in segfault or memory corruptions.


## Why does this still work

Looking at `rocksdb_transactiondb_t` and `rocksdb_t`, they are actually very similar:
https://github.com/facebook/rocksdb/blob/05a1d52e77f5b98791849aae83bad413f2e42601/db/c.cc#L133-L135
https://github.com/facebook/rocksdb/blob/05a1d52e77f5b98791849aae83bad413f2e42601/db/c.cc#L256-L258

Both only holds a single pointer to either a C++ `DB` or `TransactionDB` instance. since `TransactionDB` can safely be cast as a `DB` (or at least it seems so, based on my limited understanding of the C++ class system).

This is still hacky though :/


## Alternatives

### Extending the C API
A better alternative would be to extend the C API to be able to retrieve the base db from a transaction db, like it is possible for the optimistic transaction db type. This would require either an upstream patch and updating our rocksdb version or a custom fork...

### Reimplement GetApproximateMemoryUsageByType

Looking at `GetApproximateMemoryUsageByType` in C++, it is actually pretty simple: it fetches some properties from the dbs and caches and aggregates them:
https://github.com/facebook/rocksdb/blob/2926e0718c479c5852f3bca7a4ff8c48b69afbbd/utilities/memory/memory_util.cc#L13

The C API exports the function to access properties of a transactiondb so we could reimplement it on our side. It also means it could break or diverge from the C++ version in future updates.

