### PR TITLE
r.richter/REDSTOR-132: Add functions for rust parity

### DIFF
--- a/options.go
+++ b/options.go
@@ -683,6 +683,7 @@ func (opts *Options) SetDeleteObsoleteFilesPeriodMicros(value uint64) {
 // concurrent background jobs, submitted to
 // the default LOW priority thread pool
 // Default: 1
+// Deprecated: use SetMaxBackgroundJobs, as rocksdb decides this automatically based on the value of MaxBackgroundJobs
 func (opts *Options) SetMaxBackgroundCompactions(value int) {
 	C.rocksdb_options_set_max_background_compactions(opts.c, C.int(value))
 }
@@ -699,6 +700,7 @@ func (opts *Options) SetMaxBackgroundCompactions(value int) {
 // potentially block memtable flush jobs of other db instances, leading to
 // unnecessary Put stalls.
 // Default: 0
+// Deprecated: use SetMaxBackgroundJobs, as rocksdb decides this automatically based on the value of MaxBackgroundJobs
 func (opts *Options) SetMaxBackgroundFlushes(value int) {
 	C.rocksdb_options_set_max_background_flushes(opts.c, C.int(value))
 }

--- a/options.go
+++ b/options.go
@@ -1021,7 +1021,7 @@ func (opts *Options) SetMaxSuccessiveMerges(value int) {
 // database if set to true - jemalloc must be turned on for this to work.
 // Default: false
 func (opts *Options) SetDumpMallocStats(value bool) {
-        C.rocksdb_options_set_dump_malloc_stats(opts.c, boolToChar(value))
+	C.rocksdb_options_set_dump_malloc_stats(opts.c, boolToChar(value))
 }
 
 // EnableStatistics enable statistics.
@@ -1178,6 +1178,37 @@ func (opts *Options) SetOptimizeFiltersForHits(value bool) {
 // Default: false
 func (opts *Options) SetAtomicFlush(value bool) {
 	C.rocksdb_options_set_atomic_flush(opts.c, C.uchar(btoi(value)))
+}
+
+// SetMaxSubcompactions represents the maximum number of threads that will
+// concurrently perform a compaction job by breaking it into multiple,
+// smaller ones that are run simultaneously.
+//
+// Default: 1 (i.e. no subcompactions)
+func (opts *Options) SetMaxSubcompactions(value uint32) {
+	C.rocksdb_options_set_max_subcompactions(opts.c, C.uint32_t(value))
+}
+
+// GetMaxSubcompactions gets the maximum number of threads that will
+// concurrently perform a compaction job by breaking it into multiple,
+// smaller ones that are run simultaneously.
+func (opts *Options) GetMaxSubcompactions() uint32 {
+	return uint32(C.rocksdb_options_get_max_subcompactions(opts.c))
+}
+
+// SetMaxBackgroundJobs maximum number of concurrent background jobs
+// (compactions and flushes).
+//
+// Default: 2
+//
+// Dynamically changeable through SetDBOptions() API.
+func (opts *Options) SetMaxBackgroundJobs(value int) {
+	C.rocksdb_options_set_max_background_jobs(opts.c, C.int(value))
+}
+
+// GetMaxBackgroundJobs returns maximum number of concurrent background jobs setting.
+func (opts *Options) GetMaxBackgroundJobs() int {
+	return int(C.rocksdb_options_get_max_background_jobs(opts.c))
 }
 
 // Destroy deallocates the Options object.

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,22 @@
+package gorocksdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	opts := NewDefaultOptions()
+	defer opts.Destroy()
+
+	// Test setting max bg jobs
+	assert.Equal(t, 2, opts.GetMaxBackgroundJobs())
+	opts.SetMaxBackgroundJobs(10)
+	assert.Equal(t, 10, opts.GetMaxBackgroundJobs())
+
+	// Test setting max bg compactions
+	assert.Equal(t, uint32(1), opts.GetMaxSubcompactions())
+	opts.SetMaxSubcompactions(9)
+	assert.Equal(t, uint32(9), opts.GetMaxSubcompactions())
+}


### PR DESCRIPTION
We needed SetMaxSubcompactions and SetMaxBackgroundJobs achieve parity with our Rust implementation of iris. See TODOs here: https://github.com/DataDog/dd-go/blob/bibby/iris-node-go-app/resources/apps/iris-node-go/db/transaction_db.go#L180

We needed GetPinnedForUpdateCF to save on memcpy and improve performance.

For the ticket, we also needed NewIteratorCF on a transaction Db. This already exists here: https://github.com/DataDog/gorocksdb/blob/1a0420eeec05cd8d8aa07d871d4f939fbf945ba4/transactiondb.go#L279 (thanks, Bibby 🙌 )

All implementations were lovingly copypasta'd/adapted from https://github.com/linxGnu/grocksdb.