### PR TITLE
R.richter/REDSTOR-266: jemalloc no dump allocator for cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -28,6 +28,27 @@ func (c *Cache) GetPinnedUsage() uint64 {
 	return uint64(C.rocksdb_cache_get_pinned_usage(c.c))
 }
 
+// LRUCacheOptions are options for LRU Cache.
+type LRUCacheOptions struct {
+	c *C.rocksdb_lru_cache_options_t
+}
+
+// SetMemoryAllocator for this lru cache.
+func (l *LRUCacheOptions) SetMemoryAllocator(m *MemoryAllocator) {
+	C.rocksdb_lru_cache_options_set_memory_allocator(l.c, m.c)
+}
+
+// NewLRUCacheOptions creates lru cache options.
+func NewLRUCacheOptions() *LRUCacheOptions {
+	return &LRUCacheOptions{c: C.rocksdb_lru_cache_options_create()}
+}
+
+// Destroy lru cache options.
+func (l *LRUCacheOptions) Destroy() {
+	C.rocksdb_lru_cache_options_destroy(l.c)
+	l.c = nil
+}
+
 // Destroy deallocates the Cache object.
 func (c *Cache) Destroy() {
 	C.rocksdb_cache_destroy(c.c)

--- a/jemalloc_allocator.go
+++ b/jemalloc_allocator.go
@@ -1,0 +1,42 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+// #include "gorocksdb.h"
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+// CreateJemallocNodumpAllocator generates a memory allocator which allocates through
+// Jemalloc and utilizes MADV_DONTDUMP through madvise to exclude cache items from core dump.
+// Applications can use the allocator with block cache to exclude block cache
+// usage from core dump.
+//
+// Implementation details:
+// The JemallocNodumpAllocator creates a dedicated jemalloc arena, and all
+// allocations of the JemallocNodumpAllocator are through the same arena.
+// The memory allocator hooks memory allocation of the arena, and calls
+// madvise() with MADV_DONTDUMP flag to exclude the piece of memory from
+// core dump. Side benefit of using single arena would be reduction of jemalloc
+// metadata for some workloads.
+//
+// To mitigate mutex contention for using one single arena, jemalloc tcache
+// (thread-local cache) is enabled to cache unused allocations for future use.
+// The tcache normally incurs 0.5M extra memory usage per-thread. The usage
+// can be reduced by limiting allocation sizes to cache.
+func CreateJemallocNodumpAllocator() (*MemoryAllocator, error) {
+	var cErr *C.char
+
+	c := C.rocksdb_jemalloc_nodump_allocator_create(&cErr)
+
+	// check error
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return nil, errors.New(C.GoString(cErr))
+	}
+
+	return &MemoryAllocator{
+		c: c,
+	}, nil
+}

--- a/memory_allocator.go
+++ b/memory_allocator.go
@@ -1,0 +1,15 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+// #include "gorocksdb.h"
+import "C"
+
+// MemoryAllocator wraps a memory allocator for rocksdb.
+type MemoryAllocator struct {
+	c *C.rocksdb_memory_allocator_t
+}
+
+// Destroy the allocator.
+func (m *MemoryAllocator) Destroy() {
+	C.rocksdb_memory_allocator_destroy(m.c)
+}


### PR DESCRIPTION
We add the JemallocNoDumpAllocator is an option for the LRUCache, which we use, and is part of the larger RocksDB API. This uses jemalloc as the allocator for the cache for sure (you must have it linked/be using it anyways), but does magic under the hood to limit the cache to one arena. This arena is not dumped to the corefile on system crash, which makes crashing less painful/time-consuming and provides a security benefit as potentially sensitive data aren't written to disk.

For a better-ish explanation, see https://dev.mysql.com/doc/refman/8.0/en/innodb-buffer-pool-in-core-file.html.