### PR TITLE
Fastiter: Add unsafe pointer method

### DIFF
--- a/transactiondb.go
+++ b/transactiondb.go
@@ -280,6 +280,11 @@ func (db *TransactionDB) NewIteratorCF(opts *ReadOptions, cf *ColumnFamilyHandle
 	return NewNativeIterator(unsafe.Pointer(C.rocksdb_transactiondb_create_iterator_cf(db.c, opts.c, cf.c)))
 }
 
+// UnsafeGetDB returns the underlying c rocksdb instance.
+func (db *TransactionDB) UnsafeGetDB() unsafe.Pointer {
+	return unsafe.Pointer(db.c)
+}
+
 // Close closes the database.
 func (db *TransactionDB) Close() {
 	C.rocksdb_transactiondb_close(db.c)


### PR DESCRIPTION
To use fastiter with TransactionDB, we have to be able to open a c CF iterator manually (and not have the NativeIterator wrapping). So we need to [change this line](https://github.com/DataDog/dd-go/blob/prod/pkg/rocksutil/fastiter/iter.go#L53) (and some) to be friendly by having TransactionDB support `UnsafeGetDB`.