### PR TITLE
Revert "Add SetAllowCompaction method to FIFOCompactionOptions"

### DIFF
--- a/options_compaction.go
+++ b/options_compaction.go
@@ -37,13 +37,6 @@ func (opts *FIFOCompactionOptions) SetMaxTableFilesSize(value uint64) {
 	C.rocksdb_fifo_compaction_options_set_max_table_files_size(opts.c, C.uint64_t(value))
 }
 
-// SetAllowCompaction specifies if the compaction of the oldest files together is allowed.
-// if true, compaction will be triggered when level0_file_num_compaction_trigger
-// Default: false
-func (opts *FIFOCompactionOptions) SetAllowCompaction(allow_compaction bool) {
-	C.rocksdb_fifo_compaction_options_set_allow_compaction(opts.c, boolToChar(allow_compaction))
-}
-
 // Destroy deallocates the FIFOCompactionOptions object.
 func (opts *FIFOCompactionOptions) Destroy() {
 	C.rocksdb_fifo_compaction_options_destroy(opts.c)


### PR DESCRIPTION
Reverts DataDog/gorocksdb#41
The option is only available on rocksdb [v8.1.1](https://github.com/facebook/rocksdb/releases/tag/v8.1.1) and we are not there yet.