### PR TITLE
Enable setting of WAL compression

### DIFF
--- a/options.go
+++ b/options.go
@@ -1255,6 +1255,17 @@ func (opts *Options) SetAtomicFlush(value bool) {
 	C.rocksdb_options_set_atomic_flush(opts.c, C.uchar(btoi(value)))
 }
 
+// SetWalCompression sets wal_compression.
+//
+// At present, only ZSTD compression is supported. RocksDB will be able
+// to read compressed WAL records regardless of the current wal_compression
+// settings.
+//
+// Default: NoCompression
+func (opts *Options) SetWalCompression(value CompressionType) {
+	C.rocksdb_options_set_wal_compression(opts.c, C.int(value))
+}
+
 // Destroy deallocates the Options object.
 func (opts *Options) Destroy() {
 	C.rocksdb_options_destroy(opts.c)


### PR DESCRIPTION
RocksDB introduced WAL compression in https://github.com/facebook/rocksdb/wiki/WAL-Compression

This simply exposes that functionality in gorocksdb. As of now, only zstd compression is allowed in rocks.

[REDRES-4445]

[REDRES-4445]: https://datadoghq.atlassian.net/browse/REDRES-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ