### PR TITLE
REDRES-5466: add optimistic transaction DB in v8

### DIFF
--- a/v8/optimistic_transaction_db.go
+++ b/v8/optimistic_transaction_db.go
@@ -1,0 +1,166 @@
+package gorocksdb
+
+// #include <stdlib.h>
+// #include "rocksdb/c.h"
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+// OptimisticTransactionDB is a reusable handle to a RocksDB optimistic transactional database on disk.
+type OptimisticTransactionDB struct {
+	c    *C.rocksdb_optimistictransactiondb_t
+	name string
+	opts *Options
+}
+
+// OpenOptimisticTransactionDb opens a database with the specified options.
+func OpenOptimisticTransactionDb(
+	opts *Options,
+	name string,
+) (*OptimisticTransactionDB, error) {
+	var (
+		cErr  *C.char
+		cName = C.CString(name)
+	)
+	defer C.free(unsafe.Pointer(cName))
+	db := C.rocksdb_optimistictransactiondb_open(
+		opts.c, cName, &cErr)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return nil, errors.New(C.GoString(cErr))
+	}
+	return &OptimisticTransactionDB{
+		name: name,
+		c:    db,
+		opts: opts,
+	}, nil
+}
+
+// OpenOptimisticTransactionDbColumnFamilies opens a database with the specified column families.
+func OpenOptimisticTransactionDbColumnFamilies(
+	opts *Options,
+	name string,
+	cfNames []string,
+	cfOpts []*Options,
+) (*OptimisticTransactionDB, []*ColumnFamilyHandle, error) {
+	numColumnFamilies := len(cfNames)
+	if numColumnFamilies != len(cfOpts) {
+		return nil, nil, errors.New("must provide the same number of column family names and options")
+	}
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	cNames := make([]*C.char, numColumnFamilies)
+	for i, s := range cfNames {
+		cNames[i] = C.CString(s)
+	}
+	defer func() {
+		for _, s := range cNames {
+			C.free(unsafe.Pointer(s))
+		}
+	}()
+
+	cOpts := make([]*C.rocksdb_options_t, numColumnFamilies)
+	for i, o := range cfOpts {
+		cOpts[i] = o.c
+	}
+
+	cHandles := make([]*C.rocksdb_column_family_handle_t, numColumnFamilies)
+
+	var cErr *C.char
+	db := C.rocksdb_optimistictransactiondb_open_column_families(
+		opts.c,
+		cName,
+		C.int(numColumnFamilies),
+		&cNames[0],
+		&cOpts[0],
+		&cHandles[0],
+		&cErr,
+	)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return nil, nil, errors.New(C.GoString(cErr))
+	}
+
+	cfHandles := make([]*ColumnFamilyHandle, numColumnFamilies)
+	for i, c := range cHandles {
+		cfHandles[i] = NewNativeColumnFamilyHandle(c)
+	}
+
+	return &OptimisticTransactionDB{
+		name: name,
+		c:    db,
+		opts: opts,
+	}, cfHandles, nil
+}
+
+// TransactionBegin begins a new transaction
+// with the WriteOptions and OptimisticTransactionOptions given.
+func (db *OptimisticTransactionDB) TransactionBegin(
+	opts *WriteOptions,
+	transactionOpts *OptimisticTransactionOptions,
+	oldTransaction *Transaction,
+) *Transaction {
+	if oldTransaction != nil {
+		return NewNativeTransaction(C.rocksdb_optimistictransaction_begin(
+			db.c,
+			opts.c,
+			transactionOpts.c,
+			oldTransaction.c,
+		))
+	}
+
+	return NewNativeTransaction(C.rocksdb_optimistictransaction_begin(
+		db.c, opts.c, transactionOpts.c, nil))
+}
+
+// NewCheckpoint creates a new Checkpoint for this db.
+func (db *OptimisticTransactionDB) NewCheckpoint() (*Checkpoint, error) {
+	var (
+		cErr *C.char
+	)
+	cCheckpoint := C.rocksdb_optimistictransactiondb_checkpoint_object_create(
+		db.c, &cErr,
+	)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return nil, errors.New(C.GoString(cErr))
+	}
+
+	return NewNativeCheckpoint(cCheckpoint), nil
+}
+
+// Write writes a WriteBatch to the database
+func (db *OptimisticTransactionDB) Write(opts *WriteOptions, batch *WriteBatch) error {
+	var cErr *C.char
+	C.rocksdb_optimistictransactiondb_write(db.c, opts.c, batch.c, &cErr)
+	if cErr != nil {
+		defer C.rocksdb_free(unsafe.Pointer(cErr))
+		return errors.New(C.GoString(cErr))
+	}
+	return nil
+}
+
+// Close closes the database.
+func (db *OptimisticTransactionDB) Close() {
+	C.rocksdb_optimistictransactiondb_close(db.c)
+	db.c = nil
+}
+
+// GetBaseDB returns base-database.
+func (db *OptimisticTransactionDB) GetBaseDB() *DB {
+	return &DB{
+		c:    C.rocksdb_optimistictransactiondb_get_base_db(db.c),
+		name: db.name,
+		opts: db.opts,
+	}
+}
+
+// CloseBaseDB closes base-database.
+func (db *OptimisticTransactionDB) CloseBaseDB(base *DB) {
+	C.rocksdb_optimistictransactiondb_close_base_db(base.c)
+	base.c = nil
+}

--- a/v8/optimistic_transaction_db_test.go
+++ b/v8/optimistic_transaction_db_test.go
@@ -1,0 +1,259 @@
+package gorocksdb
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestOpenOptimisticTransactionDb(t *testing.T) {
+	db := newTestOptimisticTransactionDB(t, "TestOpenOptimisticTransactionDb")
+	defer db.Close()
+}
+
+func TestOptimisticTransactionDbColumnFamilies(t *testing.T) {
+	test_cf_names := []string{"default", "cf1", "cf2"}
+	db, cf_handles := newTestOptimisticTransactionDBColumnFamilies(t, "TestOpenOptimisticTransactionDbColumnFamilies", test_cf_names)
+	ensure.True(t, 3 == len(cf_handles))
+	defer db.Close()
+
+	cf_names, err := ListColumnFamilies(NewDefaultOptions(), db.name)
+	ensure.Nil(t, err)
+	ensure.True(t, 3 == len(cf_names))
+	ensure.DeepEqual(t, cf_names, test_cf_names)
+}
+
+func TestOptimisticTransactionDBCRUD(t *testing.T) {
+	db := newTestOptimisticTransactionDB(t, "TestOptimisticTransactionDBGet")
+	defer db.Close()
+
+	var (
+		givenKey     = []byte("hello")
+		givenVal1    = []byte("world1")
+		givenVal2    = []byte("world2")
+		givenTxnKey  = []byte("hello2")
+		givenTxnKey2 = []byte("hello3")
+		givenTxnVal1 = []byte("whatawonderful")
+		wo           = NewDefaultWriteOptions()
+		ro           = NewDefaultReadOptions()
+		to           = NewDefaultOptimisticTransactionOptions()
+	)
+
+	// Get base DB for direct operations
+	baseDB := db.GetBaseDB()
+
+	// create
+	ensure.Nil(t, baseDB.Put(wo, givenKey, givenVal1))
+
+	// retrieve
+	v1, err := baseDB.Get(ro, givenKey)
+	defer v1.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v1.Data(), givenVal1)
+
+	// update
+	ensure.Nil(t, baseDB.Put(wo, givenKey, givenVal2))
+	v2, err := baseDB.Get(ro, givenKey)
+	defer v2.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v2.Data(), givenVal2)
+
+	// delete
+	ensure.Nil(t, baseDB.Delete(wo, givenKey))
+	v3, err := baseDB.Get(ro, givenKey)
+	defer v3.Free()
+	ensure.Nil(t, err)
+	ensure.True(t, v3.Data() == nil)
+
+	// transaction
+	txn := db.TransactionBegin(wo, to, nil)
+	defer txn.Destroy()
+	// create
+	ensure.Nil(t, txn.Put(givenTxnKey, givenTxnVal1))
+	v4, err := txn.Get(ro, givenTxnKey)
+	defer v4.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v4.Data(), givenTxnVal1)
+
+	ensure.Nil(t, txn.Commit())
+	v5, err := baseDB.Get(ro, givenTxnKey)
+	defer v5.Free()
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, v5.Data(), givenTxnVal1)
+
+	// transaction
+	txn2 := db.TransactionBegin(wo, to, nil)
+	defer txn2.Destroy()
+	// create
+	ensure.Nil(t, txn2.Put(givenTxnKey2, givenTxnVal1))
+	// rollback
+	ensure.Nil(t, txn2.Rollback())
+
+	v6, err := txn2.Get(ro, givenTxnKey2)
+	defer v6.Free()
+	ensure.Nil(t, err)
+	ensure.True(t, v6.Data() == nil)
+	// transaction
+	txn3 := db.TransactionBegin(wo, to, nil)
+	defer txn3.Destroy()
+	// delete
+	ensure.Nil(t, txn3.Delete(givenTxnKey))
+	ensure.Nil(t, txn3.Commit())
+
+	v7, err := baseDB.Get(ro, givenTxnKey)
+	defer v7.Free()
+	ensure.Nil(t, err)
+	ensure.True(t, v7.Data() == nil)
+
+	db.CloseBaseDB(baseDB)
+}
+
+func TestOptimisticTransactionDBWriteBatchColumnFamilies(t *testing.T) {
+	test_cf_names := []string{"default", "cf1", "cf2"}
+	db, cf_handles := newTestOptimisticTransactionDBColumnFamilies(t, "TestOpenOptimisticTransactionDbColumnFamilies", test_cf_names)
+	ensure.True(t, len(cf_handles) == 3)
+	defer db.Close()
+
+	baseDB := db.GetBaseDB()
+	defer db.CloseBaseDB(baseDB)
+
+	var (
+		wo = NewDefaultWriteOptions()
+		ro = NewDefaultReadOptions()
+	)
+
+	// WriteBatch PutCF
+	{
+		batch := NewWriteBatch()
+		for h_idx := 1; h_idx <= 2; h_idx++ {
+			for k_idx := 0; k_idx <= 2; k_idx++ {
+				batch.PutCF(cf_handles[h_idx], []byte(fmt.Sprintf("%s_key_%d", test_cf_names[h_idx], k_idx)),
+					[]byte(fmt.Sprintf("%s_value_%d", test_cf_names[h_idx], k_idx)))
+			}
+		}
+		ensure.Nil(t, db.Write(wo, batch))
+		batch.Destroy()
+	}
+
+	// Read back
+	{
+		for h_idx := 1; h_idx <= 2; h_idx++ {
+			for k_idx := 0; k_idx <= 2; k_idx++ {
+				data, err := baseDB.GetCF(ro, cf_handles[h_idx], []byte(fmt.Sprintf("%s_key_%d", test_cf_names[h_idx], k_idx)))
+				ensure.Nil(t, err)
+				ensure.DeepEqual(t, data.Data(), []byte(fmt.Sprintf("%s_value_%d", test_cf_names[h_idx], k_idx)))
+			}
+		}
+	}
+
+	// WriteBatch DeleteCF
+	{
+		batch := NewWriteBatch()
+		batch.DeleteCF(cf_handles[1], []byte(test_cf_names[1]+"_key_0"))
+		batch.DeleteCF(cf_handles[1], []byte(test_cf_names[1]+"_key_1"))
+		ensure.Nil(t, db.Write(wo, batch))
+	}
+
+	// Read back the remaining keys
+	{
+		// All keys on "cf2" are still there.
+		// Only key2 on "cf1" still remains
+		for h_idx := 1; h_idx <= 2; h_idx++ {
+			for k_idx := 0; k_idx <= 2; k_idx++ {
+				data, err := baseDB.GetCF(ro, cf_handles[h_idx], []byte(fmt.Sprintf("%s_key_%d", test_cf_names[h_idx], k_idx)))
+				ensure.Nil(t, err)
+				if h_idx == 2 || k_idx == 2 {
+					ensure.DeepEqual(t, data.Data(), []byte(fmt.Sprintf("%s_value_%d", test_cf_names[h_idx], k_idx)))
+				} else {
+					ensure.True(t, len(data.Data()) == 0)
+				}
+			}
+		}
+	}
+}
+
+func TestOptimisticTransactionDBCRUDColumnFamilies(t *testing.T) {
+	test_cf_names := []string{"default", "cf1", "cf2"}
+	db, cf_handles := newTestOptimisticTransactionDBColumnFamilies(t, "TestOpenOptimisticTransactionDbColumnFamilies", test_cf_names)
+	ensure.True(t, len(cf_handles) == 3)
+	defer db.Close()
+
+	baseDB := db.GetBaseDB()
+	defer db.CloseBaseDB(baseDB)
+
+	var (
+		wo = NewDefaultWriteOptions()
+		ro = NewDefaultReadOptions()
+		to = NewDefaultOptimisticTransactionOptions()
+	)
+
+	{
+		txn := db.TransactionBegin(wo, to, nil)
+		defer txn.Destroy()
+		// RYW.
+		for idx, cf_handle := range cf_handles {
+			ensure.Nil(t, txn.PutCF(cf_handle, []byte(test_cf_names[idx]+"_key"), []byte(test_cf_names[idx]+"_value")))
+			val, err := txn.GetCF(ro, cf_handle, []byte(test_cf_names[idx]+"_key"))
+			defer val.Free()
+			ensure.Nil(t, err)
+			ensure.DeepEqual(t, val.Data(), []byte(test_cf_names[idx]+"_value"))
+		}
+		txn.Commit()
+	}
+
+	// Read after commit
+	for idx, cf_handle := range cf_handles {
+		val, err := baseDB.GetCF(ro, cf_handle, []byte(test_cf_names[idx]+"_key"))
+		defer val.Free()
+		ensure.Nil(t, err)
+		ensure.DeepEqual(t, val.Data(), []byte(test_cf_names[idx]+"_value"))
+	}
+
+	// Delete
+	{
+		txn := db.TransactionBegin(wo, to, nil)
+		defer txn.Destroy()
+		// RYW.
+		for idx, cf_handle := range cf_handles {
+			ensure.Nil(t, txn.DeleteCF(cf_handle, []byte(test_cf_names[idx]+"_key")))
+		}
+		txn.Commit()
+	}
+
+	// Read after delete commit
+	for idx, cf_handle := range cf_handles {
+		val, err := baseDB.GetCF(ro, cf_handle, []byte(test_cf_names[idx]+"_key"))
+		defer val.Free()
+		ensure.Nil(t, err)
+		ensure.True(t, val.Size() == 0)
+	}
+}
+
+func newTestOptimisticTransactionDB(t *testing.T, name string) *OptimisticTransactionDB {
+	dir, err := ioutil.TempDir("", "gorocksoptimistictransactiondb-"+name)
+	ensure.Nil(t, err)
+
+	opts := NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+	db, err := OpenOptimisticTransactionDb(opts, dir)
+	ensure.Nil(t, err)
+
+	return db
+}
+
+func newTestOptimisticTransactionDBColumnFamilies(t *testing.T, name string, cfNames []string) (*OptimisticTransactionDB, []*ColumnFamilyHandle) {
+	dir, err := ioutil.TempDir("", "gorocksoptimistictransactiondb-"+name)
+	ensure.Nil(t, err)
+
+	opts := NewDefaultOptions()
+	opts.SetCreateIfMissing(true)
+	opts.SetCreateIfMissingColumnFamilies(true)
+	cfOpts := []*Options{opts, opts, opts}
+	db, cfHandles, err := OpenOptimisticTransactionDbColumnFamilies(opts, dir, cfNames, cfOpts)
+	ensure.Nil(t, err)
+	ensure.True(t, 3 == len(cfHandles))
+
+	return db, cfHandles
+}

--- a/v8/options_transaction.go
+++ b/v8/options_transaction.go
@@ -64,3 +64,31 @@ func (opts *TransactionOptions) Destroy() {
 	C.rocksdb_transaction_options_destroy(opts.c)
 	opts.c = nil
 }
+
+// OptimisticTransactionOptions represent all of the available options for
+// an optimistic transaction on the database.
+type OptimisticTransactionOptions struct {
+	c *C.rocksdb_optimistictransaction_options_t
+}
+
+// NewDefaultOptimisticTransactionOptions creates a default OptimisticTransactionOptions object.
+func NewDefaultOptimisticTransactionOptions() *OptimisticTransactionOptions {
+	return NewNativeOptimisticTransactionOptions(C.rocksdb_optimistictransaction_options_create())
+}
+
+// NewNativeOptimisticTransactionOptions creates a OptimisticTransactionOptions object.
+func NewNativeOptimisticTransactionOptions(c *C.rocksdb_optimistictransaction_options_t) *OptimisticTransactionOptions {
+	return &OptimisticTransactionOptions{c}
+}
+
+// SetSetSnapshot to true is the same as calling
+// Transaction::SetSnapshot().
+func (opts *OptimisticTransactionOptions) SetSetSnapshot(value bool) {
+	C.rocksdb_optimistictransaction_options_set_set_snapshot(opts.c, boolToChar(value))
+}
+
+// Destroy deallocates the OptimisticTransactionOptions object.
+func (opts *OptimisticTransactionOptions) Destroy() {
+	C.rocksdb_optimistictransaction_options_destroy(opts.c)
+	opts.c = nil
+}


### PR DESCRIPTION
Adds OptimisticTransactionDB support to gorocksdb/v8, based on [grocksdb](https://github.com/linxGnu/grocksdb/blob/master/optimistic_transaction_db.go). Will be used for optimizing the expiration scanner in iris-lifecycle, as it's more efficient than locks when there's low contention.