### PR TITLE
Add CompactRangeOptions and CompactRangeCFOpt for bottommost compaction

### DIFF
--- a/v8/db.go
+++ b/v8/db.go
@@ -977,6 +977,14 @@ func (db *DB) CompactRangeCF(cf *ColumnFamilyHandle, r Range) {
 	C.rocksdb_compact_range_cf(db.c, cf.c, cStart, C.size_t(len(r.Start)), cLimit, C.size_t(len(r.Limit)))
 }
 
+// CompactRangeCFOpt runs a manual compaction on the Range of keys given on the
+// given column family with provided options. This is not likely to be needed for typical usage.
+func (db *DB) CompactRangeCFOpt(cf *ColumnFamilyHandle, r Range, opt *CompactRangeOptions) {
+	cStart := byteToChar(r.Start)
+	cLimit := byteToChar(r.Limit)
+	C.rocksdb_compact_range_cf_opt(db.c, cf.c, opt.c, cStart, C.size_t(len(r.Start)), cLimit, C.size_t(len(r.Limit)))
+}
+
 // Flush triggers a manuel flush for the database.
 func (db *DB) Flush(opts *FlushOptions) error {
 	var cErr *C.char

--- a/v8/options_compact_range.go
+++ b/v8/options_compact_range.go
@@ -1,0 +1,46 @@
+package gorocksdb
+
+// #include "rocksdb/c.h"
+import "C"
+
+// BottommostLevelCompaction for level based compaction, we can configure if we want to skip/force
+// bottommost level compaction.
+type BottommostLevelCompaction byte
+
+const (
+	// KSkip skip bottommost level compaction
+	KSkip BottommostLevelCompaction = 0
+	// KIfHaveCompactionFilter only compact bottommost level if there is a compaction filter
+	// This is the default option
+	KIfHaveCompactionFilter BottommostLevelCompaction = 1
+	// KForce always compact bottommost level
+	KForce BottommostLevelCompaction = 2
+	// KForceOptimized always compact bottommost level but in bottommost level avoid
+	// double-compacting files created in the same compaction
+	KForceOptimized BottommostLevelCompaction = 3
+)
+
+// CompactRangeOptions represent all of the available options for compact range.
+type CompactRangeOptions struct {
+	c *C.rocksdb_compactoptions_t
+}
+
+// NewCompactRangeOptions creates new compact range options.
+func NewCompactRangeOptions() *CompactRangeOptions {
+	return &CompactRangeOptions{
+		c: C.rocksdb_compactoptions_create(),
+	}
+}
+
+// Destroy deallocates the CompactionOptions object.
+func (opts *CompactRangeOptions) Destroy() {
+	C.rocksdb_compactoptions_destroy(opts.c)
+	opts.c = nil
+}
+
+// SetBottommostLevelCompaction sets bottommost level compaction.
+//
+// Default: KIfHaveCompactionFilter
+func (opts *CompactRangeOptions) SetBottommostLevelCompaction(value BottommostLevelCompaction) {
+	C.rocksdb_compactoptions_set_bottommost_level_compaction(opts.c, C.uchar(value))
+}


### PR DESCRIPTION
Updates from grocksdb: add option so callers can force bottommost-level compaction (CompactRangeCF alone does not compact the bottommost level unless a compaction filter is present). Needed for iris-lifecycle PR: https://github.com/ddoghq/dd-source/pull/21024